### PR TITLE
Code cleanup

### DIFF
--- a/src/main/java/frc/lib/team2930/TalonFXArmSim.java
+++ b/src/main/java/frc/lib/team2930/TalonFXArmSim.java
@@ -1,0 +1,96 @@
+package frc.lib.team2930;
+
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
+import edu.wpi.first.units.Angle;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.Velocity;
+import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
+import frc.lib.team2930.TalonFXSim.ControlMode;
+import frc.robot.Constants;
+
+public class TalonFXArmSim {
+
+  private final SingleJointedArmSim sim;
+
+  private final ProfiledPIDController feedback =
+      new ProfiledPIDController(0, 0, 0, new Constraints(0, 0));
+
+  private ControlMode control = ControlMode.VOLTAGE;
+
+  private double targetVoltage;
+  private Measure<Angle> targetPosition;
+
+  private double output;
+
+  private double kG;
+
+  public TalonFXArmSim(SingleJointedArmSim coreSim) {
+    sim = coreSim;
+  }
+
+  public void update(double dtSeconds) {
+    sim.update(dtSeconds);
+
+    if (control == ControlMode.VOLTAGE) {
+      output = targetVoltage;
+    } else {
+      output =
+          feedback.calculate(sim.getAngleRads(), targetPosition.in(Units.Radians))
+              + kG * Math.cos(sim.getAngleRads());
+    }
+
+    output = MathUtil.clamp(output, -Constants.MAX_VOLTAGE, Constants.MAX_VOLTAGE);
+
+    sim.setInputVoltage(output);
+
+    if (output == 0.0) sim.setState(sim.getAngleRads(), sim.getVelocityRadPerSec() / 2.0);
+  }
+
+  public void setControl(VoltageOut request) {
+    targetVoltage = request.Output;
+    control = ControlMode.VOLTAGE;
+  }
+
+  /**
+   * @param request position should be in Rotations
+   */
+  public void setControl(MotionMagicVoltage request) {
+    targetPosition = Units.Rotations.of(request.Position);
+    control = ControlMode.POSITION;
+  }
+
+  public double getVoltage() {
+    return output;
+  }
+
+  public Measure<Velocity<Angle>> getVelocity() {
+    return Units.RadiansPerSecond.of(sim.getVelocityRadPerSec());
+  }
+
+  public Measure<Angle> getPosition() {
+    return Units.Radians.of(sim.getAngleRads());
+  }
+
+  public void setConfig(TalonFXConfiguration config) {
+    Slot0Configs slot0Configs = config.Slot0;
+    MotionMagicConfigs mmConfigs = config.MotionMagic;
+
+    kG = slot0Configs.kG;
+
+    feedback.setPID(slot0Configs.kP, slot0Configs.kI, slot0Configs.kD);
+    feedback.setConstraints(
+        new Constraints(mmConfigs.MotionMagicCruiseVelocity, mmConfigs.MotionMagicAcceleration));
+  }
+
+  public void setState(double angleRadians, double velocityRadPerSec) {
+    sim.setState(angleRadians, velocityRadPerSec);
+  }
+}

--- a/src/main/java/frc/lib/team2930/TalonFXElevatorSim.java
+++ b/src/main/java/frc/lib/team2930/TalonFXElevatorSim.java
@@ -18,7 +18,7 @@ import frc.robot.Constants;
 public class TalonFXElevatorSim {
 
   private final ElevatorSim sim;
-  private ControlMode controlMode;
+  private ControlMode controlMode = ControlMode.VOLTAGE;
 
   private double targetVoltage;
   private double targetHeight;

--- a/src/main/java/frc/lib/team2930/TalonFXElevatorSim.java
+++ b/src/main/java/frc/lib/team2930/TalonFXElevatorSim.java
@@ -1,0 +1,97 @@
+package frc.lib.team2930;
+
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
+import edu.wpi.first.units.Distance;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.Velocity;
+import edu.wpi.first.wpilibj.simulation.ElevatorSim;
+import frc.lib.team2930.TalonFXSim.ControlMode;
+import frc.robot.Constants;
+
+public class TalonFXElevatorSim {
+
+  private final ElevatorSim sim;
+  private ControlMode controlMode;
+
+  private double targetVoltage;
+  private double targetHeight;
+
+  private double output;
+
+  private ProfiledPIDController controller;
+  private double kG;
+
+  public TalonFXElevatorSim(ElevatorSim coreSim) {
+    sim = coreSim;
+    controller = new ProfiledPIDController(0, 0, 0, new Constraints(0, 0));
+  }
+
+  public void update(double dtSeconds) {
+    sim.update(dtSeconds);
+    if (controlMode == ControlMode.VOLTAGE) {
+      output = targetVoltage;
+    } else {
+      output =
+          controller.calculate(
+                  Units.Meters.of(sim.getPositionMeters()).in(Units.Inches), targetHeight)
+              + kG;
+    }
+
+    output = MathUtil.clamp(output, -Constants.MAX_VOLTAGE, Constants.MAX_VOLTAGE);
+
+    sim.setInputVoltage(output);
+
+    if (output == 0.0)
+      sim.setState(sim.getPositionMeters(), sim.getVelocityMetersPerSecond() / 2.0);
+  }
+
+  public void setControl(VoltageOut request) {
+    targetVoltage = request.Output;
+    controlMode = ControlMode.VOLTAGE;
+  }
+
+  /** Note: this uses INCHES for position control */
+  public void setControl(MotionMagicVoltage request) {
+    targetHeight = request.Position;
+    controlMode = ControlMode.POSITION;
+  }
+
+  public double getVoltage() {
+    return output;
+  }
+
+  public Measure<Velocity<Distance>> getVelocity() {
+    return Units.MetersPerSecond.of(sim.getVelocityMetersPerSecond());
+  }
+
+  public Measure<Distance> getPosition() {
+    return Units.Meters.of(sim.getPositionMeters());
+  }
+
+  public void setConfig(TalonFXConfiguration config) {
+    Slot0Configs slot0Configs = new Slot0Configs();
+    slot0Configs = config.Slot0;
+
+    controller.setPID(slot0Configs.kP, slot0Configs.kI, slot0Configs.kD);
+    kG = slot0Configs.kG;
+    controller.setConstraints(
+        new Constraints(
+            config.MotionMagic.MotionMagicCruiseVelocity,
+            config.MotionMagic.MotionMagicAcceleration));
+  }
+
+  public void setState(double positionMeters, double velocityMetersPerSecond) {
+    sim.setState(positionMeters, velocityMetersPerSecond);
+  }
+
+  public void setSensorPosition(double positionInches) {
+    sim.setState(positionInches, sim.getVelocityMetersPerSecond());
+  }
+}

--- a/src/main/java/frc/lib/team2930/TalonFXSim.java
+++ b/src/main/java/frc/lib/team2930/TalonFXSim.java
@@ -1,0 +1,133 @@
+package frc.lib.team2930;
+
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.PositionDutyCycle;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.units.Angle;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.Velocity;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import frc.robot.Constants;
+
+public class TalonFXSim {
+
+  private DCMotorSim motor;
+  private double gearing;
+
+  private ControlMode control = ControlMode.VOLTAGE;
+
+  private double volts;
+
+  private double targetOutput;
+
+  private double kP;
+  private double kI;
+  private double kD;
+  private double kV;
+  private double kS;
+  private double kG;
+
+  private double lastError;
+
+  private double velSum;
+  private double lastVel;
+
+  private double posSum;
+  private double lastPos;
+
+  public TalonFXSim(DCMotor motorType, double gearing, double MOI) {
+    motor = new DCMotorSim(motorType, gearing, MOI);
+    this.gearing = gearing;
+  }
+
+  public void update(double dtSeconds) {
+    motor.update(dtSeconds);
+    double error;
+    double deltaError;
+
+    double adjustedVelocity = getVelocity().in(Units.RPM);
+    double adjustedPosition = getPosition().in(Units.Radian);
+    switch (control) {
+      case VOLTAGE:
+        volts = targetOutput;
+        break;
+      case VELOCITY:
+        error = targetOutput - adjustedVelocity;
+        deltaError = (error - lastError) / dtSeconds;
+        velSum += (adjustedVelocity + lastVel) / 2.0 * dtSeconds;
+        volts += kV * error + kS * velSum + kP * deltaError;
+        lastError = error;
+        break;
+      case POSITION:
+        error = targetOutput - adjustedPosition;
+        deltaError = (error - lastError) / dtSeconds;
+        posSum += (adjustedPosition + lastPos) / 2.0 * dtSeconds;
+        volts = kP * error + kI * posSum + kD * deltaError + kG;
+        lastError = error;
+        break;
+      default:
+        volts = 0;
+        break;
+    }
+
+    volts = MathUtil.clamp(volts, -Constants.MAX_VOLTAGE, Constants.MAX_VOLTAGE);
+
+    motor.setInputVoltage(volts);
+
+    lastVel = adjustedVelocity;
+    lastPos = adjustedPosition;
+
+    if (volts == 0.0)
+      motor.setState(motor.getAngularPositionRad(), motor.getAngularVelocityRadPerSec() / 2.0);
+  }
+
+  public void setControl(VoltageOut request) {
+    targetOutput = request.Output;
+    control = ControlMode.VOLTAGE;
+  }
+
+  public void setControl(VelocityVoltage request) {
+    targetOutput = request.Velocity;
+    control = ControlMode.VELOCITY;
+  }
+
+  public void setControl(PositionDutyCycle request) {
+    targetOutput = request.Position;
+    control = ControlMode.POSITION;
+  }
+
+  public void setConfig(TalonFXConfiguration config) {
+    kP = config.Slot0.kP;
+    kI = config.Slot0.kI;
+    kD = config.Slot0.kD;
+    kV = config.Slot0.kV;
+    kS = config.Slot0.kS;
+    kG = config.Slot0.kG;
+  }
+
+  public double getVoltage() {
+    return volts;
+  }
+
+  public Measure<Velocity<Angle>> getVelocity() {
+    return Units.RPM.of(motor.getAngularVelocityRPM() * gearing);
+  }
+
+  public Measure<Angle> getPosition() {
+    return Units.Radian.of(motor.getAngularPositionRad() * gearing);
+  }
+
+  public void setState(double angularPositionRad, double angularVelocityRadPerSec) {
+    motor.setState(angularPositionRad, angularVelocityRadPerSec);
+  }
+
+  public enum ControlMode {
+    VOLTAGE,
+    VELOCITY,
+    POSITION
+  }
+}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -197,14 +197,14 @@ public final class Constants {
     public static final double INTAKE_INTAKING_PERCENT_OUT = 1.0;
 
     public static final double GEARING = 1.0;
-    public static final double MOI = 5.0;
+    public static final double MOI = 0.05;
   }
 
   public static class ElevatorConstants {
     // https://ss2930.sharepoint.com/:x:/s/Engineering/ETkKz1CrsINGj5Ia29ENxT4BE_Iqd_kAK_04iaW3kLqPuQ?clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yMzExMzAyODcyNCJ9
     public static final double GEAR_RATIO = 23.05;
     public static final double PULLEY_DIAMETER = 2.256;
-    public static final double CARRIAGE_MASS = 10.0; // arbitrary
+    public static final double CARRIAGE_MASS = 3.0; // arbitrary
     public static final Measure<Distance> MAX_HEIGHT = Units.Inches.of(26.2);
     public static final Measure<Distance> MAX_LEGAL_HEIGHT = Units.Inches.of(26.2); // FIXME
     public static final Measure<Distance> TRUE_TOP_HARD_STOP = Units.Inches.of(26.5);
@@ -271,7 +271,7 @@ public final class Constants {
     }
 
     public static class Launcher {
-      public static final double MOI = 5.0;
+      public static final double MOI = 0.01;
       // FIXME: THIS VALUE HAS TO BE CONFIRMED
       public static final double GEARING = (18.0 / 30.0);
       public static final Measure<Distance> WHEEL_DIAMETER = Units.Inches.of(2.0);
@@ -324,6 +324,8 @@ public final class Constants {
   public static class ArmConstants {
     public static final double GEAR_RATIO = (50.0 / 12.0) * (50.0 / 20.0) * (42.0 / 18.0);
 
+    public static final double MOI = 0.15;
+
     public static final Rotation2d MAX_ARM_ANGLE = Rotation2d.fromDegrees(165);
     public static final Rotation2d MIN_ARM_ANGLE = Rotation2d.fromDegrees(-90);
     public static final Rotation2d HOME_POSITION = MIN_ARM_ANGLE;
@@ -332,7 +334,7 @@ public final class Constants {
 
     public static final Rotation2d TRAP_SCORE_ANGLE = Rotation2d.fromDegrees(15.0);
 
-    public static final Measure<Distance> ARM_LENGTH = Units.Inches.of(15.5);
+    public static final Measure<Distance> ARM_LENGTH = Units.Inches.of(14);
   }
 
   public static class VisionGamepieceConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -31,7 +31,8 @@ import frc.lib.team6328.Alert;
 import frc.lib.team6328.Alert.AlertType;
 import frc.robot.configs.RobotConfig;
 import frc.robot.configs.RobotConfig2023Rober;
-import frc.robot.configs.RobotConfig2024;
+import frc.robot.configs.RobotConfig2024Maestro;
+import frc.robot.configs.RobotConfig2025;
 import frc.robot.configs.SimulatorRobotConfig;
 import java.util.function.Supplier;
 
@@ -56,7 +57,7 @@ public final class Constants {
   }
 
   public static class RobotMode {
-    private static final RobotType ROBOT = RobotType.ROBOT_COMPETITION;
+    private static final RobotType ROBOT = RobotType.ROBOT_2024_RETIRED_MAESTRO;
 
     private static final Alert invalidRobotAlert =
         new Alert("Invalid robot selected, using competition robot as default.", AlertType.ERROR);
@@ -86,9 +87,9 @@ public final class Constants {
         return RobotType.ROBOT_SIMBOT;
       }
 
-      if (ROBOT != RobotType.ROBOT_COMPETITION) {
+      if (ROBOT != RobotType.ROBOT_2024_RETIRED_MAESTRO) {
         invalidRobotAlert.set(true);
-        return RobotType.ROBOT_COMPETITION;
+        return RobotType.ROBOT_2024_RETIRED_MAESTRO;
       }
 
       return ROBOT;
@@ -104,7 +105,8 @@ public final class Constants {
       ROBOT_SIMBOT(SimulatorRobotConfig::new),
       ROBOT_SIMBOT_REAL_CAMERAS(SimulatorRobotConfig::new),
       ROBOT_2023_RETIRED_ROBER(RobotConfig2023Rober::new),
-      ROBOT_COMPETITION(RobotConfig2024::new);
+      ROBOT_2024_RETIRED_MAESTRO(RobotConfig2024Maestro::new),
+      ROBOT_2025(RobotConfig2025::new);
 
       public final Supplier<RobotConfig> config;
 
@@ -122,9 +124,8 @@ public final class Constants {
 
   public static double MAX_VOLTAGE = 12.0;
 
-  public static class FieldConstants {
+  public static class FieldConstants { // TODO: check all constants for new season
     // official Field dimensions
-    // https://github.com/wpilibsuite/allwpilib/blob/main/apriltag/src/main/native/resources/edu/wpi/first/apriltag/2024-crescendo.json.
     public static double FIELD_LENGTH = 16.541;
     public static double FIELD_WIDTH = 8.211;
 
@@ -188,37 +189,44 @@ public final class Constants {
       public static final double STALL_CURRENT_AMPS = 40.0;
       public static final double FREE_CURRENT_AMPS = 30.0;
       public static final double FREE_SPEED_RPM = 6000.0;
+      public static final double SUPPLY_VOLTAGE_TIME = 0.02;
     }
   }
 
-  public static class IntakeConstants {
+  public static class IntakeConstants { // TODO: check all constants for new season
     public static final double INTAKE_IDLE_PERCENT_OUT = 0.8;
 
     public static final double INTAKE_INTAKING_PERCENT_OUT = 1.0;
 
     public static final double GEARING = 1.0;
     public static final double MOI = 0.05;
+
+    public static final double SUPPLY_CURRENT_LIMIT = 40.0;
+    public static final String ROOT_TABLE = "Intake";
   }
 
-  public static class ElevatorConstants {
-    // https://ss2930.sharepoint.com/:x:/s/Engineering/ETkKz1CrsINGj5Ia29ENxT4BE_Iqd_kAK_04iaW3kLqPuQ?clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yMzExMzAyODcyNCJ9
+  public static class ElevatorConstants { // TODO: check all constants for new season
     public static final double GEAR_RATIO = 23.05;
-    public static final double PULLEY_DIAMETER = 2.256;
-    public static final double CARRIAGE_MASS = 3.0; // arbitrary
+    public static final Measure<Distance> PULLEY_DIAMETER = Units.Inches.of(2.256);
+    public static final double CARRIAGE_MASS = 10.0; // arbitrary
+
+    public static final double INCHES_TO_MOTOR_ROT =
+        Constants.ElevatorConstants.GEAR_RATIO
+            / (Math.PI * Constants.ElevatorConstants.PULLEY_DIAMETER.in(Units.Inches));
+
     public static final Measure<Distance> MAX_HEIGHT = Units.Inches.of(26.2);
     public static final Measure<Distance> MAX_LEGAL_HEIGHT = Units.Inches.of(26.2); // FIXME
     public static final Measure<Distance> TRUE_TOP_HARD_STOP = Units.Inches.of(26.5);
 
     public static final Measure<Distance> SAFE_HEIGHT = Units.Inches.of(15.491);
-    public static final Measure<Distance> SUPPLY_CURRENT_LIMIT = Units.Inches.of(40.0);
+    public static final double SUPPLY_CURRENT_LIMIT = 40.0;
 
-    // FIXME: home position needs to be changed now that we added spacers to
-    // swerveModule
     public static final Measure<Distance> HOME_POSITION = Units.Inches.of(7.35);
     public static final Measure<Distance> LOADING_POSITION = Units.Inches.of(7.35); // was 7.5
+    public static final String ROOT_TABLE = "Elevator";
   }
 
-  public static class ShooterConstants {
+  public static class ShooterConstants { // TODO: check all constants for new season
     public static final double PREP_RPM = 2500.0;
     public static final double SHOOTING_RPM = 8000.0;
     public static final double SHOOTING_PERCENT_OUT = 0.95;
@@ -227,7 +235,7 @@ public final class Constants {
     public static final Measure<Distance> MAX_SHOOTING_DISTANCE = Units.Inches.of(180.0);
 
     public static final double SHOOTING_SPEED =
-        SHOOTING_RPM / 60.0 * Launcher.WHEEL_DIAMETER.in(Units.Meters) * Math.PI;
+        SHOOTING_RPM / 60.0 * LauncherConstants.WHEEL_DIAMETER.in(Units.Meters) * Math.PI;
 
     public static final double SHOOTING_TIME = 0.2;
 
@@ -238,9 +246,14 @@ public final class Constants {
         new Translation3d(
             SHOOTER_OFFSET.getX(), SHOOTER_OFFSET.getY(), Units.Inches.of(5).in(Units.Meters));
 
-    public static class Pivot {
-      // TODO: fix these values:
+    public static final String ROOT_TABLE = "Shooter";
+
+    public static class PivotConstants { // TODO: check all constants for new season
       public static final double GEARING = 125.0;
+
+      public static final double SUPPLY_CURRENT_LIMIT = 40.0;
+      public static final double SUPPLY_CURRENT_THRESHOLD = 60.0;
+      public static final double SUPPLY_TIME_THRESHOLD = 0.1;
 
       public static final Rotation2d MIN_ANGLE_RAD = Rotation2d.fromDegrees(12.0);
       public static final Rotation2d MAX_ANGLE_RAD =
@@ -268,23 +281,27 @@ public final class Constants {
         }
         return PITCH_ADJUSTMENT_MAP.get(distance.in(Units.Meters));
       }
+
+      public static final String ROOT_TABLE = "Pivot";
     }
 
-    public static class Launcher {
+    public static class LauncherConstants { // TODO: check all constants for new season
       public static final double MOI = 0.01;
-      // FIXME: THIS VALUE HAS TO BE CONFIRMED
       public static final double GEARING = (18.0 / 30.0);
       public static final Measure<Distance> WHEEL_DIAMETER = Units.Inches.of(2.0);
+      public static final double SUPPLY_CURRENT_LIMIT = 40.0;
+      public static final double SUPPLY_CURRENT_THRESHOLD = 60.0;
+      public static final double SUPPLY_TIME_THRESHOLD = 0.1;
+      public static final String ROOT_TABLE = "Launcher";
     }
   }
 
-  public static class LEDConstants {
-    // TODO: check these values
+  public static class LEDConstants { // TODO: check all constants for new season
     public static final int PWM_PORT = 9;
     public static final int MAX_LED_LENGTH = 60;
   }
 
-  public static class CanIDs {
+  public static class CanIDs { // TODO: check all constants for new season
     // READ ME: CAN ID's THAT ARE NOT VALID TO USE
     // 1, 11, 21, 31
     // 2, 12, 22, 32
@@ -297,7 +314,6 @@ public final class Constants {
 
     public static final int SHOOTER_CAN_ID = 33;
     public static final int SHOOTER_PIVOT_CAN_ID = 32;
-    public static final int SHOOTER_KICKER_CAN_ID = 35;
     public static final int SHOOTER_TOF_CAN_ID = 38;
 
     public static final int ARM_CAN_ID = 17;
@@ -305,15 +321,11 @@ public final class Constants {
     public static final int ELEVATOR_CAN_ID = 37;
 
     public static final int END_EFFECTOR_CAN_ID = 30;
-    public static final int END_EFFECTOR_INTAKE_SIDE_TOF_CAN_ID = 39;
-    public static final int END_EFFECTOR_SHOOTER_SIDE_TOF_CAN_ID = 40;
 
     public static final int GYRO_2_CAN_ID = 41;
   }
 
-  public static class DIOPorts {
-    // TODO: get actual DIO ports
-  }
+  public static class DIOPorts {}
 
   public enum ControlMode {
     POSITION,
@@ -321,7 +333,9 @@ public final class Constants {
     VOLTAGE
   }
 
-  public static class ArmConstants {
+  public static class ArmConstants { // TODO: check all constants for new season
+    public static final double SUPPLY_CURRENT_LIMIT = 40.0;
+
     public static final double GEAR_RATIO = (50.0 / 12.0) * (50.0 / 20.0) * (42.0 / 18.0);
 
     public static final double MOI = 0.15;
@@ -335,21 +349,31 @@ public final class Constants {
     public static final Rotation2d TRAP_SCORE_ANGLE = Rotation2d.fromDegrees(15.0);
 
     public static final Measure<Distance> ARM_LENGTH = Units.Inches.of(14);
+
+    public static final String ROOT_TABLE = "Arm";
   }
 
-  public static class VisionGamepieceConstants {
+  public static class VisionGamepieceConstants { // TODO: check all constants for new season
     public static final Pose3d GAMEPIECE_CAMERA_POSE =
         new Pose3d(
             Units.Inches.of(5.3).in(Units.Meters),
             0.0,
             Units.Inches.of(18.725).in(Units.Meters),
             new Rotation3d(0.0, Math.toRadians(-12), 0.0));
-    public static final String CAMERA_NAME = RobotConfig2024.OBJECT_DETECTION_CAMERA_NAME;
+    public static final String CAMERA_NAME = RobotConfig2024Maestro.OBJECT_DETECTION_CAMERA_NAME;
+    public static final int RESOLUTION_WIDTH_PIXELS = 960;
+    public static final int RESOLUTION_HEIGHT_PIXELS = 720;
+    public static final Rotation2d FOV_DIAGONAL = Rotation2d.fromDegrees(128.2);
+    public static final double AVERAGE_ERROR_PIXELS = 0.35;
+    public static final double AVERAGE_STANDARD_DEVIATION_PIXELS = 0.1;
+    public static final double FPS = 15;
+    public static final double AVERAGE_LATENCY_MS = 25;
+    public static final double AVERAGE_STANDARD_DEVIATION_MS = 10;
   }
 
-  public static class AutoConstants {
+  public static class AutoConstants { // TODO: check all constants for new season
     public static final Measure<Distance> DIST_TO_START_INTAKING = Units.Meters.of(1.0);
   }
 
-  public static boolean unusedCode = false;
+  public static final boolean unusedCode = false;
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -19,6 +19,7 @@ import com.pathplanner.lib.util.PIDConstants;
 import com.pathplanner.lib.util.ReplanningConfig;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
@@ -38,6 +39,7 @@ import frc.robot.autonomous.AutosManager;
 import frc.robot.autonomous.AutosManager.Auto;
 import frc.robot.autonomous.AutosSubsystems;
 import frc.robot.commands.drive.DrivetrainDefaultTeleopDrive;
+import frc.robot.commands.elevator.ElevatorSetHeight;
 import frc.robot.commands.intake.IntakeGamepiece;
 import frc.robot.commands.led.LedSetStateForSeconds;
 import frc.robot.configs.SimulatorRobotConfig;
@@ -89,8 +91,8 @@ public class RobotContainer {
 
   private final Drivetrain drivetrain;
   private final DrivetrainWrapper drivetrainWrapper;
-  public final AprilTagFieldLayout aprilTagLayout;
-  public final Vision vision;
+  private final AprilTagFieldLayout aprilTagLayout;
+  private final Vision vision;
   private final Arm arm;
   private final Elevator elevator;
   private final Intake intake;
@@ -116,13 +118,13 @@ public class RobotContainer {
   public DigitalInput breakModeButton = new DigitalInput(0);
   public DigitalInput homeSensorsButton = new DigitalInput(1);
 
-  Trigger breakModeButtonTrigger =
+  private Trigger breakModeButtonTrigger =
       new Trigger(() -> !breakModeButton.get() && !DriverStation.isEnabled());
 
-  Trigger homeSensorsButtonTrigger =
+  private Trigger homeSensorsButtonTrigger =
       new Trigger(() -> !homeSensorsButton.get() && !DriverStation.isEnabled());
 
-  boolean brakeModeTriggered = true;
+  private boolean brakeModeTriggered = true;
 
   private boolean is_teleop;
   private boolean is_autonomous;
@@ -207,7 +209,7 @@ public class RobotContainer {
                   config,
                   drivetrain::getPoseEstimatorPose),
             };
-            // Sim Cameras
+
             vision =
                 new Vision(
                     aprilTagLayout,
@@ -256,13 +258,34 @@ public class RobotContainer {
           led = new LED(() -> brakeModeTriggered, drivetrain::isGyroConnected);
           break;
 
-        case ROBOT_COMPETITION:
-          // README: for development purposes, comment any of the real IO's you DON'T want
-          // to use
-          // and
-          // uncomment the empty IO's as a replacement
+        case ROBOT_2024_RETIRED_MAESTRO:
+          drivetrain =
+              new Drivetrain(
+                  config,
+                  new GyroIOPigeon2(config, config.getGyroCANID()),
+                  new GyroIOPigeon2(config, Constants.CanIDs.GYRO_2_CAN_ID),
+                  config.getSwerveModuleObjects(),
+                  () -> is_autonomous);
+          intake = new Intake(new IntakeIOReal());
+          elevator = new Elevator(new ElevatorIOReal());
+          arm = new Arm(new ArmIOReal());
+          shooter = new Shooter(new ShooterIOReal());
+          vision =
+              new Vision(
+                  aprilTagLayout,
+                  drivetrain::getPoseEstimatorPose,
+                  drivetrain::getRotationGyroOnly,
+                  drivetrain::addVisionEstimate,
+                  config.getVisionModuleObjects());
 
-          // -- All real IO's
+          visionGamepiece =
+              new VisionGamepiece(
+                  new VisionGamepieceIOReal(), drivetrain::getPoseEstimatorPoseAtTimestamp);
+
+          led = new LED(() -> brakeModeTriggered, drivetrain::isGyroConnected);
+          break;
+
+        case ROBOT_2025:
           drivetrain =
               new Drivetrain(
                   config,
@@ -407,6 +430,9 @@ public class RobotContainer {
                     }));
 
     // ---------- OPERATOR CONTROLS -----------
+
+    operatorController.a().whileTrue(new ElevatorSetHeight(elevator, Units.Inches.of(5)));
+    operatorController.b().whileTrue(new ElevatorSetHeight(elevator, Units.Inches.of(18)));
 
     twenty_Second_Warning.onTrue(
         new LedSetStateForSeconds(led, RobotState.TWENTY_SECOND_WARNING, 0.5));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -106,8 +106,12 @@ public class RobotContainer {
   private final HashMap<String, Supplier<Auto>> stringToAutoSupplierMap = new HashMap<>();
   private final AutosManager autoManager;
 
-  private Trigger gamepieceInRobot;
-  private final Trigger twenty_Second_Warning;
+  private Trigger gamepieceInRobot =
+      new Trigger(
+          () -> false); // TODO: move to constructor and add condition for gamepiece in robot
+  private final Trigger
+      twenty_Second_Warning; // TODO: decide whether this is necessary. If it is, make sure to test
+  // it.
 
   public DigitalInput breakModeButton = new DigitalInput(0);
   public DigitalInput homeSensorsButton = new DigitalInput(1);

--- a/src/main/java/frc/robot/commands/elevator/ElevatorSetHeight.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorSetHeight.java
@@ -6,24 +6,17 @@ package frc.robot.commands.elevator;
 
 import edu.wpi.first.units.Distance;
 import edu.wpi.first.units.Measure;
-import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.lib.team2930.LoggerEntry;
-import frc.lib.team2930.LoggerGroup;
 import frc.robot.subsystems.elevator.Elevator;
 import java.util.function.Supplier;
 
 public class ElevatorSetHeight extends Command {
-  private static final String ROOT_TABLE = "ElevatorSetHeight";
 
-  private static final LoggerGroup logGroup = LoggerGroup.build(ROOT_TABLE);
-  private static final LoggerEntry.Decimal log_targetHeight = logGroup.buildDecimal("targetHeight");
-
-  /** Creates a new ElevatorSetHeight. */
   private final Elevator elevator;
 
   private final Supplier<Measure<Distance>> heightSupplier;
 
+  /** Creates a new ElevatorSetHeight. */
   public ElevatorSetHeight(Elevator elevator, Supplier<Measure<Distance>> heightSupplier) {
     this.elevator = elevator;
     this.heightSupplier = heightSupplier;
@@ -43,7 +36,6 @@ public class ElevatorSetHeight extends Command {
   @Override
   public void execute() {
     elevator.setHeight(heightSupplier.get());
-    log_targetHeight.info(heightSupplier.get().in(Units.Inches));
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/intake/IntakeSetRPM.java
+++ b/src/main/java/frc/robot/commands/intake/IntakeSetRPM.java
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.intake;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.intake.Intake;
+import java.util.function.DoubleSupplier;
+
+public class IntakeSetRPM extends Command {
+
+  private Intake intake;
+  private DoubleSupplier RPM;
+
+  /** Creates a new IntakeSetRPM. */
+  public IntakeSetRPM(Intake intake, DoubleSupplier RPM) {
+
+    this.intake = intake;
+    this.RPM = RPM;
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(intake);
+  }
+
+  public IntakeSetRPM(Intake intake, double RPM) {
+    this(intake, () -> RPM);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    intake.setVelocity(RPM.getAsDouble());
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    intake.setPercentOut(0);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/shooter/ShooterSetLauncherRPM.java
+++ b/src/main/java/frc/robot/commands/shooter/ShooterSetLauncherRPM.java
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.shooter;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.shooter.Shooter;
+import java.util.function.DoubleSupplier;
+
+public class ShooterSetLauncherRPM extends Command {
+
+  private Shooter shooter;
+  private DoubleSupplier RPM;
+
+  /** Creates a new IntakeSetRPM. */
+  public ShooterSetLauncherRPM(Shooter shooter, DoubleSupplier RPM) {
+
+    this.shooter = shooter;
+    this.RPM = RPM;
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(shooter);
+  }
+
+  public ShooterSetLauncherRPM(Shooter shooter, double RPM) {
+    this(shooter, () -> RPM);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    shooter.setLauncherRPM(RPM.getAsDouble());
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    shooter.setLauncherPercentOut(0);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/shooter/ShooterSetPivotAngle.java
+++ b/src/main/java/frc/robot/commands/shooter/ShooterSetPivotAngle.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.shooter;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.shooter.Shooter;
+import java.util.function.Supplier;
+
+public class ShooterSetPivotAngle extends Command {
+  /** Creates a new ArmSetAngle. */
+  Shooter shooter;
+
+  Supplier<Rotation2d> angleSupplier;
+
+  public ShooterSetPivotAngle(Shooter shooter, Rotation2d angle) {
+    this(shooter, () -> angle);
+  }
+
+  public ShooterSetPivotAngle(Shooter shooter, Supplier<Rotation2d> angleSupplier) {
+    this.shooter = shooter;
+    this.angleSupplier = angleSupplier;
+
+    addRequirements(shooter);
+  }
+
+  @Override
+  public void execute() {
+    shooter.setPivotPosition(angleSupplier.get());
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/configs/RobotConfig2024Maestro.java
+++ b/src/main/java/frc/robot/configs/RobotConfig2024Maestro.java
@@ -20,11 +20,9 @@ import frc.robot.subsystems.swerve.SwerveModuleIOTalonFX;
 import frc.robot.subsystems.swerve.SwerveModules;
 import frc.robot.subsystems.vision.VisionModuleConfiguration;
 
-public class RobotConfig2024 extends RobotConfig {
+public class RobotConfig2024Maestro extends RobotConfig {
 
   private static final boolean PHOENIX_PRO_LICENSE = true;
-
-  // TODO: ----- !IMPORTANT! FILL IN ALL VALUES !IMPORTANT! -----
 
   // ------------ SWERVE ---------------------
   private static final Measure<Distance> WHEEL_RADIUS = Units.Inches.of(1.957);

--- a/src/main/java/frc/robot/configs/RobotConfig2025.java
+++ b/src/main/java/frc/robot/configs/RobotConfig2025.java
@@ -1,0 +1,376 @@
+package frc.robot.configs;
+
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.signals.InvertedValue;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.units.Distance;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.Units;
+import frc.lib.constants.SwerveModuleConstants;
+import frc.lib.team6328.LoggedTunableNumber;
+import frc.robot.subsystems.swerve.SwerveModule;
+import frc.robot.subsystems.swerve.SwerveModuleIO;
+import frc.robot.subsystems.swerve.SwerveModuleIOTalonFX;
+import frc.robot.subsystems.swerve.SwerveModules;
+import frc.robot.subsystems.vision.VisionModuleConfiguration;
+
+public class RobotConfig2025 extends RobotConfig {
+
+  private static final boolean PHOENIX_PRO_LICENSE = true;
+
+  // TODO: ----- !IMPORTANT! FILL IN ALL VALUES !IMPORTANT! -----
+
+  // ------------ SWERVE ---------------------
+  private static final Measure<Distance> WHEEL_RADIUS = Units.Inches.of(1.957);
+
+  // ------ SWERVE MODULE CONFIGURATIONS: CANID + OFFSET + INVERTS --------------
+  // 0
+  private static final IndividualSwerveModuleConfig FRONT_LEFT_MODULE_CONFIG =
+      new IndividualSwerveModuleConfig(
+          1,
+          11,
+          21,
+          Rotation2d.fromRotations(0.199),
+          InvertedValue.CounterClockwise_Positive,
+          InvertedValue.Clockwise_Positive);
+  // 1
+  private static final IndividualSwerveModuleConfig FRONT_RIGHT_MODULE_CONFIG =
+      new IndividualSwerveModuleConfig(
+          2,
+          12,
+          22,
+          Rotation2d.fromRotations(0.152),
+          InvertedValue.CounterClockwise_Positive,
+          InvertedValue.Clockwise_Positive);
+  // 2
+  private static final IndividualSwerveModuleConfig BACK_LEFT_MODULE_CONFIG =
+      new IndividualSwerveModuleConfig(
+          3,
+          13,
+          23,
+          Rotation2d.fromRotations(-0.326),
+          InvertedValue.CounterClockwise_Positive,
+          InvertedValue.Clockwise_Positive);
+  // 3
+  private static final IndividualSwerveModuleConfig BACK_RIGHT_MODULE_CONFIG =
+      new IndividualSwerveModuleConfig(
+          4,
+          14,
+          24,
+          Rotation2d.fromRotations(0.448),
+          InvertedValue.CounterClockwise_Positive,
+          InvertedValue.Clockwise_Positive);
+
+  // -------- SWERVE CURRENT LIMITS ---------
+  private static final CurrentLimitsConfigs DRIVE_TALON_CURRENT_LIMIT_CONFIGS =
+      new CurrentLimitsConfigs()
+          .withSupplyCurrentLimit(20)
+          .withSupplyCurrentThreshold(30)
+          .withSupplyTimeThreshold(0.1)
+          .withSupplyCurrentLimitEnable(true);
+
+  private static final CurrentLimitsConfigs STEER_TALON_CURRENT_LIMIT_CONFIGS =
+      new CurrentLimitsConfigs()
+          .withSupplyCurrentLimit(25)
+          .withSupplyCurrentThreshold(40)
+          .withSupplyTimeThreshold(0.1)
+          .withSupplyCurrentLimitEnable(true);
+
+  // --------- SWERVE GEAR RATIO ---------
+  public static final double SWERVE_DRIVE_GEAR_RATIO =
+      SwerveModuleConstants.MK4I.LEVEL_3_GEARING_DRIVE_GEAR_RATIO_PLUS_SPEED_KIT;
+  public static final double SWERVE_STEER_GEAR_RATIO =
+      SwerveModuleConstants.MK4I.GEARING_TURN_GEAR_RATIO;
+
+  // ---------- SWERVE STEERING MOTOR PID CONSTANTS -----------
+  // FIXE: RN copied from Mechanical advantage (6328) 2023 codebase. Should learn to tune
+  // ourselves
+  private static final LoggedTunableNumber ANGLE_KP = group.build("ANGLE_KP", 200.0);
+  private static final LoggedTunableNumber ANGLE_KD = group.build("ANGLE_KD", 2.0);
+
+  // ---------- SWERVE DRIVE MOTOR PID + KS + KV + KA CONSTANTS -------------
+  private static final LoggedTunableNumber DRIVE_KP = group.build("DRIVE_KP", 1.8);
+  private static final LoggedTunableNumber DRIVE_KD = group.build("DRIVE_KD", 0.0);
+
+  private static final LoggedTunableNumber DRIVE_KS = group.build("DRIVE_KS", 0.0);
+  private static final LoggedTunableNumber DRIVE_KV = group.build("DRIVE_KV", 0.8);
+  private static final LoggedTunableNumber DRIVE_KA = group.build("DRIVE_KA", 0.0);
+
+  // -------- GYRO CAN ID ---------
+  private static final int GYRO_CAN_ID = 5;
+
+  // -------- GYRO OFFSETS --------
+
+  private static final double GYRO_MOUNTING_PITCH = 0.0;
+
+  private static final double GYRO_MOUNTING_ROLL = -180.0;
+
+  private static final double GYRO_MOUNTING_YAW = 90.0;
+
+  // -------- CAN BUS NAME -----------
+  private static final String CAN_BUS_NAME = "CANivore";
+
+  // -------- ROBOT DIMENSIONS -----------
+  // front to back
+  private static final Measure<Distance> TRACK_WIDTH_X = Units.Inches.of(21.75);
+  // left to right
+  private static final Measure<Distance> TRACK_WIDTH_Y = Units.Inches.of(21.75);
+
+  // ------- ROBOT MAX SPEED --------
+  private static final double MAX_VELOCITY_METERS_PER_SECOND = 5.0;
+  private static final double MAX_COAST_VELOCITY_METERS_PER_SECOND = 0.05;
+
+  // ------- AUTONOMOUS CONSTANTS -------
+  private static final LoggedTunableNumber AUTO_MAX_SPEED_METERS_PER_SECOND =
+      group.build("AUTO_MAX_SPEED", 2.0);
+  private static final LoggedTunableNumber AUTO_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED =
+      group.build("AUTO_MAX_ACCEL", 2.0);
+
+  private static final LoggedTunableNumber AUTO_TRANSLATION_KP =
+      group.build("AUTO_TRANSLATION_KP", 2.4);
+  private static final LoggedTunableNumber AUTO_TRANSLATION_KI =
+      group.build("AUTO_TRANSLATION_KI", 0.0);
+  private static final LoggedTunableNumber AUTO_TRANSLATION_KD =
+      group.build("AUTO_TRANSLATION_KD", 0.0);
+  private static final LoggedTunableNumber AUTO_THETA_KP = group.build("AUTO_THETA_KP", 4.0);
+  private static final LoggedTunableNumber AUTO_THETA_KI = group.build("AUTO_THETA_KI", 0.0);
+  private static final LoggedTunableNumber AUTO_THETA_KD = group.build("AUTO_THETA_KD", 0.0);
+
+  // ---- VISION  -------
+  public static final Transform3d SHOOTER_SIDE_LEFT =
+      new Transform3d(
+          new Translation3d(
+              Units.Inches.of(-0.21682).in(Units.Meters),
+              Units.Inches.of(6.7949).in(Units.Meters),
+              Units.Inches.of(24.259267).in(Units.Meters)),
+          new Rotation3d(Math.toRadians(180.0), Math.toRadians(-22.0), Math.toRadians(225.0)));
+
+  public static final Transform3d SHOOTER_SIDE_RIGHT =
+      new Transform3d(
+          new Translation3d(
+              Units.Inches.of(-0.21682).in(Units.Meters),
+              Units.Inches.of(-6.7949).in(Units.Meters),
+              Units.Inches.of(24.259267).in(Units.Meters)),
+          new Rotation3d(Math.toRadians(180.0), Math.toRadians(-22.0), Math.toRadians(135.0)));
+
+  public static final Transform3d INTAKE_SIDE_LEFT =
+      new Transform3d(
+          new Translation3d(
+              Units.Inches.of(2.143069).in(Units.Meters),
+              Units.Inches.of(12.127149).in(Units.Meters),
+              Units.Inches.of(24.990728).in(Units.Meters)),
+          new Rotation3d(Math.toRadians(0.0), Math.toRadians(-22.0), Math.toRadians(35.0)));
+
+  public static final Transform3d INTAKE_SIDE_RIGHT =
+      new Transform3d(
+          new Translation3d(
+              Units.Inches.of(2.143069).in(Units.Meters),
+              Units.Inches.of(-12.127149).in(Units.Meters),
+              Units.Inches.of(24.990728).in(Units.Meters)),
+          new Rotation3d(Math.toRadians(0.0), Math.toRadians(-22.0), Math.toRadians(325.0)));
+
+  public static final String OBJECT_DETECTION_CAMERA_NAME = "0_Object_Detection_ELP";
+  public static final String SHOOTER_SIDE_LEFT_CAMERA_NAME = "1_Shooter_Left_See3Cam";
+  public static final String SHOOTER_SIDE_RIGHT_CAMERA_NAME = "2_Shooter_Right_See3Cam";
+
+  public static final AprilTagFields APRIL_TAG_FIELD = AprilTagFields.k2024Crescendo;
+
+  /*
+   *
+   *
+   * FUNCTIONS RETURNING CONSTANTS:
+   *
+   * YOU MUST CHANGED 2 METHODS:
+   * getSwerveModuleObjects()
+   * getVisionModuleObjects()
+   *
+   */
+
+  // FIXME: define your swerve module objects here
+  @Override
+  public SwerveModules getSwerveModuleObjects() {
+    return new SwerveModules(
+        new SwerveModule(0, this, new SwerveModuleIOTalonFX(this, FRONT_LEFT_MODULE_CONFIG)),
+        new SwerveModule(1, this, new SwerveModuleIOTalonFX(this, FRONT_RIGHT_MODULE_CONFIG)),
+        new SwerveModule(2, this, new SwerveModuleIOTalonFX(this, BACK_LEFT_MODULE_CONFIG)),
+        new SwerveModule(3, this, new SwerveModuleIOTalonFX(this, BACK_RIGHT_MODULE_CONFIG)));
+  }
+
+  @Override
+  public SwerveModules getReplaySwerveModuleObjects() {
+    return new SwerveModules(
+        new SwerveModule(0, this, new SwerveModuleIO.Fake()),
+        new SwerveModule(1, this, new SwerveModuleIO.Fake()),
+        new SwerveModule(2, this, new SwerveModuleIO.Fake()),
+        new SwerveModule(3, this, new SwerveModuleIO.Fake()));
+  }
+
+  // FIXME: define vision modules here
+  @Override
+  public VisionModuleConfiguration[] getVisionModuleObjects() {
+    return new VisionModuleConfiguration[] {
+      VisionModuleConfiguration.build(SHOOTER_SIDE_LEFT_CAMERA_NAME, SHOOTER_SIDE_LEFT),
+      VisionModuleConfiguration.build(SHOOTER_SIDE_RIGHT_CAMERA_NAME, SHOOTER_SIDE_RIGHT)
+    };
+  }
+
+  @Override
+  public VisionModuleConfiguration[] getReplayVisionModules() {
+    return new VisionModuleConfiguration[] {
+      VisionModuleConfiguration.buildReplayStub(SHOOTER_SIDE_LEFT_CAMERA_NAME, SHOOTER_SIDE_LEFT),
+      VisionModuleConfiguration.buildReplayStub(SHOOTER_SIDE_RIGHT_CAMERA_NAME, SHOOTER_SIDE_RIGHT)
+    };
+  }
+
+  @Override
+  public AprilTagFieldLayout getAprilTagFieldLayout() {
+    return APRIL_TAG_FIELD.loadAprilTagLayoutField();
+  }
+
+  @Override
+  public boolean getPhoenix6Licensed() {
+    return PHOENIX_PRO_LICENSE;
+  }
+
+  @Override
+  public IndividualSwerveModuleConfig[] getIndividualModuleConfigurations() {
+    return new IndividualSwerveModuleConfig[] {
+      FRONT_LEFT_MODULE_CONFIG,
+      FRONT_RIGHT_MODULE_CONFIG,
+      BACK_LEFT_MODULE_CONFIG,
+      BACK_RIGHT_MODULE_CONFIG
+    };
+  }
+
+  @Override
+  public int getGyroCANID() {
+    return GYRO_CAN_ID;
+  }
+
+  @Override
+  public Measure<Distance> getTrackWidth_Y() {
+    return TRACK_WIDTH_Y;
+  }
+
+  @Override
+  public Measure<Distance> getTrackWidth_X() {
+    return TRACK_WIDTH_X;
+  }
+
+  @Override
+  public double getRobotMaxLinearVelocity() {
+    return MAX_VELOCITY_METERS_PER_SECOND;
+  }
+
+  @Override
+  public double getRobotMaxCoastVelocity() {
+    return MAX_COAST_VELOCITY_METERS_PER_SECOND;
+  }
+
+  @Override
+  public String getCANBusName() {
+    return CAN_BUS_NAME;
+  }
+
+  @Override
+  public LoggedTunableNumber getDriveKS() {
+    return DRIVE_KS;
+  }
+
+  @Override
+  public LoggedTunableNumber getDriveKV() {
+    return DRIVE_KV;
+  }
+
+  @Override
+  public LoggedTunableNumber getDriveKA() {
+    return DRIVE_KA;
+  }
+
+  @Override
+  public LoggedTunableNumber getDriveKP() {
+    return DRIVE_KP;
+  }
+
+  @Override
+  public LoggedTunableNumber getDriveKD() {
+    return DRIVE_KD;
+  }
+
+  @Override
+  public LoggedTunableNumber getAngleKP() {
+    return ANGLE_KP;
+  }
+
+  @Override
+  public LoggedTunableNumber getAngleKD() {
+    return ANGLE_KD;
+  }
+
+  @Override
+  public LoggedTunableNumber getAutoMaxSpeed() {
+    return AUTO_MAX_SPEED_METERS_PER_SECOND;
+  }
+
+  @Override
+  public LoggedTunableNumber getAutoMaxAcceleration() {
+    return AUTO_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED;
+  }
+
+  @Override
+  public PIDController getAutoTranslationPidController() {
+    return new PIDController(
+        AUTO_TRANSLATION_KP.get(), AUTO_TRANSLATION_KI.get(), AUTO_TRANSLATION_KD.get());
+  }
+
+  @Override
+  public PIDController getAutoThetaPidController() {
+    return new PIDController(AUTO_THETA_KP.get(), AUTO_THETA_KI.get(), AUTO_THETA_KD.get());
+  }
+
+  @Override
+  public Measure<Distance> getWheelRadius() {
+    return WHEEL_RADIUS;
+  }
+
+  @Override
+  public double getSwerveModuleDriveGearRatio() {
+    return SWERVE_DRIVE_GEAR_RATIO;
+  }
+
+  @Override
+  public double getSwerveModuleTurnGearRatio() {
+    return SWERVE_STEER_GEAR_RATIO;
+  }
+
+  @Override
+  public CurrentLimitsConfigs getDriveTalonCurrentLimitConfig() {
+    return DRIVE_TALON_CURRENT_LIMIT_CONFIGS;
+  }
+
+  @Override
+  public CurrentLimitsConfigs getSteerTalonCurrentLimitConfig() {
+    return STEER_TALON_CURRENT_LIMIT_CONFIGS;
+  }
+
+  @Override
+  public double getGyroMountingPitch() {
+    return GYRO_MOUNTING_PITCH;
+  }
+
+  @Override
+  public double getGyroMountingRoll() {
+    return GYRO_MOUNTING_ROLL;
+  }
+
+  @Override
+  public double getGyroMountingYaw() {
+    return GYRO_MOUNTING_YAW;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/LED.java
+++ b/src/main/java/frc/robot/subsystems/LED.java
@@ -160,6 +160,8 @@ public class LED extends SubsystemBase {
         });
   }
 
+  // Setters
+
   private void setSolidColor(Color color) {
     for (int i = 0; i < ledBuffer.getLength(); i++) {
       ledBuffer.setLED(i, color);
@@ -254,24 +256,34 @@ public class LED extends SubsystemBase {
     // theta=" + theta);
   }
 
-  public RobotState getCurrentState() {
-    return robotState;
-  }
-
   public void setBaseRobotState(BaseRobotState baseRobotState) {
     this.baseRobotState = baseRobotState;
-  }
-
-  public BaseRobotState getCurrentBaseState() {
-    return baseRobotState;
   }
 
   public void setGamepieceStatus(boolean gamepieceInRobot) {
     this.gamepieceInRobot = gamepieceInRobot;
   }
 
+  // Getters
+
+  public RobotState getCurrentState() {
+    return robotState;
+  }
+
+  public BaseRobotState getCurrentBaseState() {
+    return baseRobotState;
+  }
+
   public boolean getGamepieceStatus() {
     return gamepieceInRobot;
+  }
+
+  public boolean sameAsPrevBuffer() {
+    for (int i = 0; i < ledBuffer.getLength(); i++) {
+      if (!ledBuffer.getLED(i).equals(previousBuffer.getLED(i))) return false;
+    }
+
+    return true;
   }
 
   public enum RobotState {
@@ -294,13 +306,5 @@ public class LED extends SubsystemBase {
     GOAL_LINE_UP,
     SHOOTING_PREP,
     SHOOTER_SUCCESS
-  }
-
-  public boolean sameAsPrevBuffer() {
-    for (int i = 0; i < ledBuffer.getLength(); i++) {
-      if (!ledBuffer.getLED(i).equals(previousBuffer.getLED(i))) return false;
-    }
-
-    return true;
   }
 }

--- a/src/main/java/frc/robot/subsystems/arm/ArmIO.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIO.java
@@ -10,11 +10,10 @@ public interface ArmIO {
   /** Contains all of the input data received from hardware. */
   class Inputs extends BaseInputs {
     public Rotation2d armPosition = Constants.zeroRotation2d;
-    public double armAngleDegrees;
     public double armAppliedVolts;
     public double armCurrentAmps;
     public double armTempCelsius;
-    public double armVelocity;
+    public double armVelocityRPM;
 
     public Inputs(LoggerGroup logInputs) {
       super(logInputs);

--- a/src/main/java/frc/robot/subsystems/arm/ArmIO.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIO.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.arm;
 
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.lib.team2930.LoggerGroup;
@@ -13,7 +14,7 @@ public interface ArmIO {
     public double armAppliedVolts;
     public double armCurrentAmps;
     public double armTempCelsius;
-    public double armVelocityRPM;
+    public double armVelocityDegreesPerSecond;
 
     public Inputs(LoggerGroup logInputs) {
       super(logInputs);
@@ -30,11 +31,7 @@ public interface ArmIO {
   public default void setClosedLoopPosition(Rotation2d angle) {}
 
   public default void setClosedLoopConstants(
-      double kP,
-      double kD,
-      double kG,
-      double maxProfiledVelocity,
-      double maxProfiledAcceleration) {}
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {}
 
   public default boolean setNeutralMode(NeutralModeValue value) {
     return false;

--- a/src/main/java/frc/robot/subsystems/arm/ArmIOReal.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIOReal.java
@@ -82,11 +82,10 @@ public class ArmIOReal implements ArmIO {
 
     // could look into latency compensating this value
     inputs.armPosition = Rotation2d.fromRotations(positionRotations.getValueAsDouble());
-    inputs.armAngleDegrees = inputs.armPosition.getDegrees();
     inputs.armAppliedVolts = appliedVols.getValueAsDouble();
     inputs.armCurrentAmps = currentAmps.getValueAsDouble();
     inputs.armTempCelsius = tempCelsius.getValueAsDouble();
-    inputs.armVelocity = velocity.getValueAsDouble();
+    inputs.armVelocityRPM = velocity.getValueAsDouble();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/arm/ArmIOSim.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIOSim.java
@@ -1,96 +1,74 @@
 package frc.robot.subsystems.arm;
 
-import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.controller.ProfiledPIDController;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
-import edu.wpi.first.units.Distance;
-import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
+import frc.lib.team2930.TalonFXArmSim;
 import frc.robot.Constants;
 
 public class ArmIOSim implements ArmIO {
-  private final double MOMENT_OF_INERTIA = 0.15;
-  private final Measure<Distance> ARM_LENGTH = Units.Inches.of(14);
 
-  SingleJointedArmSim armSim =
-      new SingleJointedArmSim(
-          DCMotor.getFalcon500Foc(1),
-          Constants.ArmConstants.GEAR_RATIO,
-          MOMENT_OF_INERTIA,
-          ARM_LENGTH.in(Units.Meters),
-          Constants.ArmConstants.MIN_ARM_ANGLE.getRadians(),
-          Constants.ArmConstants.MAX_ARM_ANGLE.getRadians(),
-          false,
-          0);
+  private TalonFXArmSim armSim =
+      new TalonFXArmSim(
+          new SingleJointedArmSim(
+              DCMotor.getFalcon500Foc(1),
+              Constants.ArmConstants.GEAR_RATIO,
+              Constants.ArmConstants.MOI,
+              Constants.ArmConstants.ARM_LENGTH.in(Units.Meters),
+              Constants.ArmConstants.MIN_ARM_ANGLE.getRadians(),
+              Constants.ArmConstants.MAX_ARM_ANGLE.getRadians(),
+              false,
+              0));
 
-  private final ProfiledPIDController feedback;
+  private VoltageOut openLoopControl = new VoltageOut(0);
+  private MotionMagicVoltage closedLoopControl = new MotionMagicVoltage(0);
 
-  private double kG;
-
-  private boolean closedLoop = false;
-  private Rotation2d closedLoopTargetAngle = Constants.zeroRotation2d;
-  private double openLoopVolts = 0.0;
-
-  public ArmIOSim() {
-    feedback = new ProfiledPIDController(0, 0, 0, new Constraints(0, 0));
-  }
+  public ArmIOSim() {}
 
   @Override
   public void updateInputs(Inputs inputs) {
-    var controlEffort = 0.0;
-
-    if (closedLoop) {
-      var fb =
-          feedback.calculate(inputs.armPosition.getRadians(), closedLoopTargetAngle.getRadians());
-      var ff = kG * Math.cos(armSim.getAngleRads());
-
-      controlEffort = fb + ff;
-
-      Arm.logSIM_FF_fG.info(ff);
-      Arm.logSIM_error.info(feedback.getPositionError());
-
-    } else {
-      controlEffort = openLoopVolts;
-    }
-
-    controlEffort = MathUtil.clamp(controlEffort, -12, 12);
-
-    armSim.setInputVoltage(controlEffort);
     armSim.update(Constants.kDefaultPeriod);
 
-    inputs.armPosition = Rotation2d.fromRadians(armSim.getAngleRads());
-    inputs.armAngleDegrees = inputs.armPosition.getDegrees();
-    inputs.armAppliedVolts = controlEffort;
-    inputs.armCurrentAmps = armSim.getCurrentDrawAmps();
-
-    Arm.logSIM_error.info(feedback.getPositionError());
-    Arm.logSIM_controlEffort.info(controlEffort);
+    inputs.armPosition = new Rotation2d(armSim.getPosition().in(Units.Radian));
+    inputs.armAppliedVolts = armSim.getVoltage();
+    inputs.armVelocityRPM = armSim.getVelocity().in(Units.RPM);
   }
 
   @Override
   public void setVoltage(double volts) {
-    openLoopVolts = volts;
-    closedLoop = false;
+    armSim.setControl(openLoopControl.withOutput(volts));
   }
 
   @Override
   public void setClosedLoopPosition(Rotation2d angle) {
-    closedLoop = true;
-    closedLoopTargetAngle = angle;
-    openLoopVolts = 0.0;
+    armSim.setControl(
+        closedLoopControl.withPosition(Units.Degrees.of(angle.getDegrees()).in(Units.Rotations)));
   }
 
   @Override
   public void setClosedLoopConstants(
       double kP, double kD, double kG, double maxProfiledVelocity, double maxProfiledAcceleration) {
+    TalonFXConfiguration config = new TalonFXConfiguration();
+    Slot0Configs slot0Configs = new Slot0Configs();
+    MotionMagicConfigs mmConfigs = new MotionMagicConfigs();
 
-    this.kG = kG;
-    feedback.setP(kP);
-    feedback.setD(kD);
-    feedback.setConstraints(new Constraints(maxProfiledVelocity, maxProfiledAcceleration));
+    slot0Configs.kP = kP;
+    slot0Configs.kD = kD;
+    slot0Configs.kG = kG;
+
+    mmConfigs.MotionMagicCruiseVelocity = maxProfiledVelocity;
+    mmConfigs.MotionMagicAcceleration = maxProfiledAcceleration;
+
+    config.Slot0 = slot0Configs;
+    config.MotionMagic = mmConfigs;
+
+    armSim.setConfig(config);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/arm/ArmIOSim.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmIOSim.java
@@ -37,7 +37,7 @@ public class ArmIOSim implements ArmIO {
 
     inputs.armPosition = new Rotation2d(armSim.getPosition().in(Units.Radian));
     inputs.armAppliedVolts = armSim.getVoltage();
-    inputs.armVelocityRPM = armSim.getVelocity().in(Units.RPM);
+    inputs.armVelocityDegreesPerSecond = armSim.getVelocity().in(Units.DegreesPerSecond);
   }
 
   @Override
@@ -53,17 +53,13 @@ public class ArmIOSim implements ArmIO {
 
   @Override
   public void setClosedLoopConstants(
-      double kP, double kD, double kG, double maxProfiledVelocity, double maxProfiledAcceleration) {
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {
     TalonFXConfiguration config = new TalonFXConfiguration();
     Slot0Configs slot0Configs = new Slot0Configs();
-    MotionMagicConfigs mmConfigs = new MotionMagicConfigs();
 
     slot0Configs.kP = kP;
     slot0Configs.kD = kD;
     slot0Configs.kG = kG;
-
-    mmConfigs.MotionMagicCruiseVelocity = maxProfiledVelocity;
-    mmConfigs.MotionMagicAcceleration = maxProfiledAcceleration;
 
     config.Slot0 = slot0Configs;
     config.MotionMagic = mmConfigs;

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
@@ -1,7 +1,7 @@
 package frc.robot.subsystems.elevator;
 
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.signals.NeutralModeValue;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.Distance;
 import edu.wpi.first.units.Measure;
 import frc.lib.team2930.LoggerGroup;
@@ -28,7 +28,8 @@ public interface ElevatorIO {
 
   public default void setHeight(Measure<Distance> height) {}
 
-  public default void setPIDConstraints(double kP, double kD, double kG, Constraints constraints) {}
+  public default void setClosedLoopConstants(
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {}
 
   public default void setSensorPosition(Measure<Distance> position) {}
 

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
@@ -10,11 +10,11 @@ import frc.robot.subsystems.BaseInputs;
 public interface ElevatorIO {
   /** Contains all of the input data received from hardware. */
   class Inputs extends BaseInputs {
-    public double heightInches = 0.0;
-    public double velocityInchesPerSecond = 0.0;
-    public double appliedVolts = 0.0;
-    public double currentAmps = 0.0;
-    public double tempCelsius = 0.0;
+    public double heightInches;
+    public double velocityInchesPerSecond;
+    public double appliedVolts;
+    public double currentAmps;
+    public double tempCelsius;
 
     public Inputs(LoggerGroup logInputs) {
       super(logInputs);

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
@@ -13,7 +13,6 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.Distance;
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
@@ -115,22 +114,19 @@ public class ElevatorIOReal implements ElevatorIO {
   }
 
   @Override
-  public void setPIDConstraints(double kP, double kD, double kG, Constraints constraints) {
+  public void setClosedLoopConstants(
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {
     Slot0Configs pidConfig = new Slot0Configs();
-    MotionMagicConfigs mmConfig = new MotionMagicConfigs();
 
     motor.getConfigurator().refresh(pidConfig);
-    motor.getConfigurator().refresh(mmConfig);
+    motor.getConfigurator().refresh(mmConfigs);
 
     pidConfig.kP = kP;
     pidConfig.kD = kD;
     pidConfig.kG = kG;
 
-    mmConfig.MotionMagicCruiseVelocity = constraints.maxVelocity;
-    mmConfig.MotionMagicAcceleration = constraints.maxAcceleration;
-
     motor.getConfigurator().apply(pidConfig);
-    motor.getConfigurator().apply(mmConfig);
+    motor.getConfigurator().apply(mmConfigs);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOReal.java
@@ -18,15 +18,12 @@ import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
 import frc.robot.Constants;
 import frc.robot.Constants.ElevatorConstants;
+import frc.robot.Constants.MotorConstants.KrakenConstants;
 
 public class ElevatorIOReal implements ElevatorIO {
 
   private final TalonFX motor = new TalonFX(Constants.CanIDs.ELEVATOR_CAN_ID);
 
-  private static final double inchesToMotorRot =
-      Constants.ElevatorConstants.GEAR_RATIO
-          / (Math.PI * Constants.ElevatorConstants.PULLEY_DIAMETER);
-  // FIXME: add FOC
   private final MotionMagicVoltage closedLoopControl =
       new MotionMagicVoltage(0.0).withEnableFOC(true);
   private final VoltageOut openLoopControl = new VoltageOut(0.0).withEnableFOC(true);
@@ -40,30 +37,30 @@ public class ElevatorIOReal implements ElevatorIO {
   private final BaseStatusSignal[] refreshSet;
 
   public ElevatorIOReal() {
+    // Motor config
     TalonFXConfiguration config = new TalonFXConfiguration();
 
-    // FIXME: maybe make this more aggressive?
-    config.CurrentLimits.SupplyCurrentLimit = 40.0;
+    config.CurrentLimits.SupplyCurrentLimit = ElevatorConstants.SUPPLY_CURRENT_LIMIT;
     config.CurrentLimits.SupplyCurrentLimitEnable = true;
 
     config.MotorOutput.NeutralMode = NeutralModeValue.Brake;
     config.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
 
-    // config.Voltage.PeakForwardVoltage = 2.0;
-    // config.Voltage.PeakReverseVoltage = -2.0;
-
     config.SoftwareLimitSwitch.ForwardSoftLimitThreshold =
-        ElevatorConstants.MAX_HEIGHT.in(Units.Inches) * inchesToMotorRot;
+        ElevatorConstants.MAX_HEIGHT.in(Units.Inches) * ElevatorConstants.INCHES_TO_MOTOR_ROT;
     config.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
 
-    config.SoftwareLimitSwitch.ReverseSoftLimitThreshold = 0.0 * inchesToMotorRot;
+    config.SoftwareLimitSwitch.ReverseSoftLimitThreshold =
+        0.0 * ElevatorConstants.INCHES_TO_MOTOR_ROT;
     config.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
 
     config.Slot0.GravityType = GravityTypeValue.Elevator_Static;
 
-    config.Voltage.SupplyVoltageTimeConstant = 0.02;
+    config.Voltage.SupplyVoltageTimeConstant = KrakenConstants.SUPPLY_VOLTAGE_TIME;
 
     motor.getConfigurator().apply(config);
+
+    // Status signals
 
     rotorPosition = motor.getRotorPosition();
     rotorVelocity = motor.getRotorVelocity();
@@ -71,14 +68,14 @@ public class ElevatorIOReal implements ElevatorIO {
     currentAmps = motor.getStatorCurrent();
     tempCelsius = motor.getDeviceTemp();
 
+    // Update status signals
+
     BaseStatusSignal.setUpdateFrequencyForAll(100, rotorPosition, rotorVelocity);
     BaseStatusSignal.setUpdateFrequencyForAll(50, appliedVolts, currentAmps);
     BaseStatusSignal.setUpdateFrequencyForAll(1, tempCelsius);
 
     motor.optimizeBusUtilization();
 
-    // leftServo.setAlwaysHighMode();
-    // rightServo.setAlwaysHighMode();
     refreshSet =
         new BaseStatusSignal[] {
           rotorPosition, rotorVelocity, appliedVolts, currentAmps, tempCelsius
@@ -89,8 +86,9 @@ public class ElevatorIOReal implements ElevatorIO {
   public void updateInputs(Inputs inputs) {
     inputs.refreshAll(refreshSet);
 
-    inputs.heightInches = rotorPosition.getValueAsDouble() / inchesToMotorRot;
-    inputs.velocityInchesPerSecond = rotorVelocity.getValueAsDouble() / inchesToMotorRot;
+    inputs.heightInches = rotorPosition.getValueAsDouble() / ElevatorConstants.INCHES_TO_MOTOR_ROT;
+    inputs.velocityInchesPerSecond =
+        rotorVelocity.getValueAsDouble() / ElevatorConstants.INCHES_TO_MOTOR_ROT;
     inputs.appliedVolts = appliedVolts.getValueAsDouble();
     inputs.currentAmps = currentAmps.getValueAsDouble();
     inputs.tempCelsius = tempCelsius.getValueAsDouble();
@@ -104,13 +102,13 @@ public class ElevatorIOReal implements ElevatorIO {
 
   @Override
   public void setHeight(Measure<Distance> height) {
-    closedLoopControl.withPosition(height.in(Units.Inches) * inchesToMotorRot);
+    closedLoopControl.withPosition(height.in(Units.Inches) * ElevatorConstants.INCHES_TO_MOTOR_ROT);
     motor.setControl(closedLoopControl);
   }
 
   @Override
   public void setSensorPosition(Measure<Distance> position) {
-    motor.setPosition(position.in(Units.Inches) * inchesToMotorRot);
+    motor.setPosition(position.in(Units.Inches) * ElevatorConstants.INCHES_TO_MOTOR_ROT);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
@@ -21,7 +21,7 @@ public class ElevatorIOSim implements ElevatorIO {
               DCMotor.getKrakenX60Foc(1),
               Constants.ElevatorConstants.GEAR_RATIO,
               Constants.ElevatorConstants.CARRIAGE_MASS,
-              Constants.ElevatorConstants.PULLEY_DIAMETER / 2.0,
+              Constants.ElevatorConstants.PULLEY_DIAMETER.in(Units.Meters) / 2.0,
               0.0,
               Constants.ElevatorConstants.MAX_HEIGHT.in(Units.Meter),
               true,

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
@@ -1,84 +1,73 @@
 package frc.robot.subsystems.elevator;
 
-import edu.wpi.first.math.controller.ProfiledPIDController;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.Distance;
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
-import frc.lib.team2930.ControlMode;
+import frc.lib.team2930.TalonFXElevatorSim;
 import frc.robot.Constants;
 
 public class ElevatorIOSim implements ElevatorIO {
-  private final ElevatorSim sim =
-      new ElevatorSim(
-          DCMotor.getKrakenX60Foc(2),
-          Constants.ElevatorConstants.GEAR_RATIO,
-          Constants.ElevatorConstants.CARRIAGE_MASS,
-          Units.Inches.of(Constants.ElevatorConstants.PULLEY_DIAMETER).in(Units.Meters) / 2,
-          0.0,
-          Constants.ElevatorConstants.MAX_HEIGHT.in(Units.Meters),
-          false,
-          Units.Inches.of(8.0).in(Units.Meters));
 
-  private Measure<Distance> targetHeight = Units.Meters.zero();
+  private final TalonFXElevatorSim sim =
+      new TalonFXElevatorSim(
+          new ElevatorSim(
+              DCMotor.getKrakenX60Foc(1),
+              Constants.ElevatorConstants.GEAR_RATIO,
+              Constants.ElevatorConstants.CARRIAGE_MASS,
+              Constants.ElevatorConstants.PULLEY_DIAMETER / 2.0,
+              0.0,
+              Constants.ElevatorConstants.MAX_HEIGHT.in(Units.Meter),
+              true,
+              0));
 
-  private final ProfiledPIDController feedback =
-      new ProfiledPIDController(0.0, 0.0, 0.0, new Constraints(0.0, 0.0));
-
-  private double kG = 0.0;
-
-  private ControlMode controlMode = ControlMode.OPEN_LOOP;
-
-  private double openLoopVolts = 0.0;
-
-  private double appliedVolts = 0.0;
+  private VoltageOut openLoopControl = new VoltageOut(0);
+  private MotionMagicVoltage closedLoopControl = new MotionMagicVoltage(0);
 
   public ElevatorIOSim() {}
 
   @Override
   public void updateInputs(Inputs inputs) {
     sim.update(Constants.kDefaultPeriod);
-    Elevator.logSIM_ActualTargetHeight.info(targetHeight.in(Units.Inches));
-    if (controlMode.equals(ControlMode.CLOSED_LOOP)) {
-      appliedVolts = feedback.calculate(inputs.heightInches, targetHeight.in(Units.Inches)) + kG;
-    } else {
-      appliedVolts = openLoopVolts;
-    }
-
-    Elevator.logSIM_Error.info(feedback.getPositionError());
-
-    sim.setInputVoltage(appliedVolts);
-
-    inputs.appliedVolts = appliedVolts;
-    inputs.currentAmps = sim.getCurrentDrawAmps();
-    inputs.heightInches = Units.Meters.of(sim.getPositionMeters()).in(Units.Inches);
-    inputs.velocityInchesPerSecond =
-        Units.Meters.of(sim.getVelocityMetersPerSecond()).in(Units.Inches);
+    inputs.appliedVolts = sim.getVoltage();
+    inputs.velocityInchesPerSecond = sim.getVelocity().in(Units.InchesPerSecond);
+    inputs.heightInches = sim.getPosition().in(Units.Inches);
   }
 
   @Override
   public void setVoltage(double volts) {
-    openLoopVolts = volts;
-    controlMode = ControlMode.OPEN_LOOP;
+    sim.setControl(openLoopControl.withOutput(volts));
   }
 
   @Override
   public void setHeight(Measure<Distance> height) {
-    targetHeight = height;
-    controlMode = ControlMode.CLOSED_LOOP;
+    sim.setControl(closedLoopControl.withPosition(height.in(Units.Inch)));
   }
 
   @Override
   public void setSensorPosition(Measure<Distance> position) {
-    sim.setState(position.in(Units.Meters), 0.0);
+    sim.setSensorPosition(position.in(Units.Inches));
   }
 
   @Override
-  public void setPIDConstraints(double kP, double kD, double kG, Constraints constraints) {
-    feedback.setPID(kP, 0.0, kD);
-    this.kG = kG;
-    feedback.setConstraints(constraints);
+  public void setClosedLoopConstants(
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {
+    TalonFXConfiguration config = new TalonFXConfiguration();
+    Slot0Configs slot0Configs = new Slot0Configs();
+
+    slot0Configs.kP = kP;
+    slot0Configs.kD = kD;
+    slot0Configs.kG = kG;
+
+    config.Slot0 = slot0Configs;
+    config.MotionMagic = mmConfigs;
+
+    sim.setConfig(config);
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -5,105 +5,126 @@
 package frc.robot.subsystems.intake;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.lib.team2930.ControlMode;
 import frc.lib.team2930.ExecutionTiming;
 import frc.lib.team2930.LoggerEntry;
 import frc.lib.team2930.LoggerGroup;
 import frc.lib.team2930.TunableNumberGroup;
 import frc.lib.team6328.LoggedTunableNumber;
 import frc.robot.Constants;
+import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.RobotMode.RobotType;
 
 public class Intake extends SubsystemBase {
-  public static final String ROOT_TABLE = "Intake";
+  // Execution timing
+  private static final ExecutionTiming timing = new ExecutionTiming(IntakeConstants.ROOT_TABLE);
 
-  private static final ExecutionTiming timing = new ExecutionTiming(ROOT_TABLE);
-
-  private static final LoggerGroup logInputs = LoggerGroup.build(ROOT_TABLE);
+  // Logging
+  private static final LoggerGroup logGroup = LoggerGroup.build(IntakeConstants.ROOT_TABLE);
   private static final LoggerEntry.Decimal logInputs_velocityRPM =
-      logInputs.buildDecimal("VelocityRPM");
+      logGroup.buildDecimal("VelocityRPM");
   private static final LoggerEntry.Decimal logInputs_currentAmps =
-      logInputs.buildDecimal("CurrentAmps");
+      logGroup.buildDecimal("CurrentAmps");
   private static final LoggerEntry.Decimal logInputs_tempCelsius =
-      logInputs.buildDecimal("TempCelsius");
+      logGroup.buildDecimal("TempCelsius");
   private static final LoggerEntry.Decimal logInputs_appliedVolts =
-      logInputs.buildDecimal("AppliedVolts");
+      logGroup.buildDecimal("AppliedVolts");
 
   private static final LoggerEntry.Decimal logTargetVelocityRPM =
-      logInputs.buildDecimal("TargetVelocityRPM");
+      logGroup.buildDecimal("TargetVelocityRPM");
+  private static final LoggerEntry.EnumValue<ControlMode> logControlMode =
+      logGroup.buildEnum("ControlMode");
 
-  private double targetRPM;
+  // Tunable numbers
 
-  private static final TunableNumberGroup group = new TunableNumberGroup(ROOT_TABLE);
+  private static final TunableNumberGroup group =
+      new TunableNumberGroup(IntakeConstants.ROOT_TABLE);
 
   private static final LoggedTunableNumber kS = group.build("kS");
   private static final LoggedTunableNumber kP = group.build("kP");
   private static final LoggedTunableNumber kV = group.build("kV");
-  private static final LoggedTunableNumber maxProfiledAcceleration =
-      group.build("ClosedLoopMaxAccelerationConstraint");
+  private static final LoggedTunableNumber targetAccelerationConfig =
+      group.build("MaxAccelerationConstraint");
 
   static {
-    if (Constants.RobotMode.getRobot() == RobotType.ROBOT_COMPETITION) {
+    if (Constants.RobotMode.getRobot() == RobotType.ROBOT_2024_RETIRED_MAESTRO) {
       kS.initDefault(0);
       kP.initDefault(0.8);
       kV.initDefault(0.15);
-      maxProfiledAcceleration.initDefault(300.0);
+      targetAccelerationConfig.initDefault(300.0);
     } else if (Constants.RobotMode.isSimBot()) {
       kS.initDefault(0);
       kP.initDefault(0.0006);
       kV.initDefault(0.0002);
-      maxProfiledAcceleration.initDefault(0.0);
+      targetAccelerationConfig.initDefault(0.0);
     }
   }
 
   private final IntakeIO io;
-  private final IntakeIO.Inputs inputs = new IntakeIO.Inputs(logInputs);
+  private final IntakeIO.Inputs inputs = new IntakeIO.Inputs(logGroup);
+
+  private double targetRPM;
+
+  private ControlMode controlMode = ControlMode.OPEN_LOOP;
 
   /** Creates a new Intake. */
   public Intake(IntakeIO io) {
     this.io = io;
 
     setConstants();
+
+    io.setVoltage(0.0);
   }
 
   @Override
   public void periodic() {
     try (var ignored = timing.start()) {
-      // Intake Logging
+      // Logging
       io.updateInputs(inputs);
       logInputs_velocityRPM.info(inputs.velocityRPM);
       logInputs_currentAmps.info(inputs.currentAmps);
       logInputs_tempCelsius.info(inputs.tempCelsius);
       logInputs_appliedVolts.info(inputs.appliedVolts);
 
+      logControlMode.info(controlMode);
+
+      // Update tunable numbers
+
       var hc = hashCode();
       if (kS.hasChanged(hc)
           || kP.hasChanged(hc)
           || kV.hasChanged(hc)
-          || maxProfiledAcceleration.hasChanged(hc)) {
+          || targetAccelerationConfig.hasChanged(hc)) {
         setConstants();
       }
     }
   }
 
-  private void setConstants() {
-    io.setClosedLoopConstants(kP.get(), kV.get(), kS.get(), maxProfiledAcceleration.get());
-  }
+  // Setters
 
-  public double getCurrentDraw() {
-    return inputs.currentAmps;
+  private void setConstants() {
+    io.setClosedLoopConstants(kP.get(), kV.get(), kS.get(), targetAccelerationConfig.get());
   }
 
   public void setPercentOut(double percent) {
     io.setVoltage(percent * Constants.MAX_VOLTAGE);
-  }
-
-  public double getRPM() {
-    return inputs.velocityRPM;
+    controlMode = ControlMode.OPEN_LOOP;
   }
 
   public void setVelocity(double revPerMin) {
     io.setVelocity(revPerMin);
     targetRPM = revPerMin;
     logTargetVelocityRPM.info(targetRPM);
+    controlMode = ControlMode.CLOSED_LOOP;
+  }
+
+  // Getters
+
+  public double getCurrentDraw() {
+    return inputs.currentAmps;
+  }
+
+  public double getRPM() {
+    return inputs.velocityRPM;
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -6,10 +6,10 @@ import frc.robot.subsystems.BaseInputs;
 public interface IntakeIO {
   /** Contains all of the input data received from hardware. */
   class Inputs extends BaseInputs {
-    public double velocityRPM = 0.0;
-    public double currentAmps = 0.0;
-    public double tempCelsius = 0.0;
-    public double appliedVolts = 0.0;
+    public double velocityRPM;
+    public double currentAmps;
+    public double tempCelsius;
+    public double appliedVolts;
 
     public Inputs(LoggerGroup logInputs) {
       super(logInputs);
@@ -24,5 +24,5 @@ public interface IntakeIO {
   public default void setVelocity(double revPerMin) {}
 
   public default void setClosedLoopConstants(
-      double kP, double kV, double kS, double maxProfiledAcceleration) {}
+      double kP, double kV, double kS, double targetAccelerationConfig) {}
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -1,30 +1,56 @@
 package frc.robot.subsystems.intake;
 
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import edu.wpi.first.units.Units;
+import frc.lib.team2930.TalonFXSim;
 import frc.robot.Constants;
 
 public class IntakeIOSim implements IntakeIO {
 
-  private DCMotorSim motor =
-      new DCMotorSim(
+  private TalonFXSim motor =
+      new TalonFXSim(
           DCMotor.getKrakenX60Foc(1),
           Constants.IntakeConstants.GEARING,
           Constants.IntakeConstants.MOI);
 
-  private double voltage = 0.0;
+  private VoltageOut openLoopControl = new VoltageOut(0);
+  private VelocityVoltage closedLoopControl = new VelocityVoltage(0);
 
   public IntakeIOSim() {}
 
   @Override
   public void updateInputs(Inputs inputs) {
     motor.update(Constants.kDefaultPeriod);
-    motor.setInputVoltage(voltage);
-    inputs.currentAmps = motor.getCurrentDrawAmps();
+    inputs.appliedVolts = motor.getVoltage();
+    inputs.velocityRPM = motor.getVelocity().in(Units.RPM);
   }
 
   @Override
   public void setVoltage(double volts) {
-    volts = voltage;
+    motor.setControl(openLoopControl.withOutput(volts));
+  }
+
+  @Override
+  public void setVelocity(double revPerMin) {
+    motor.setControl(closedLoopControl.withVelocity(revPerMin));
+  }
+
+  @Override
+  public void setClosedLoopConstants(
+      double kP, double kV, double kS, double maxProfiledAcceleration) {
+    TalonFXConfiguration config = new TalonFXConfiguration();
+    Slot0Configs slot0Configs = new Slot0Configs();
+
+    slot0Configs.kP = kP;
+    slot0Configs.kV = kV;
+    slot0Configs.kS = kS;
+
+    config.Slot0 = slot0Configs;
+
+    motor.setConfig(config);
   }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
@@ -11,13 +11,13 @@ public interface ShooterIO {
   /** Contains all of the input data received from hardware. */
   class Inputs extends BaseInputs {
     public Rotation2d pivotPosition = Constants.zeroRotation2d;
-    public double pivotVelocityRadsPerSec = 0.0;
-    public double pivotAppliedVolts = 0.0;
-    public double pivotCurrentAmps = 0.0;
+    public double pivotVelocityDegreesPerSec;
+    public double pivotAppliedVolts;
+    public double pivotCurrentAmps;
 
-    public double launcherRPM = 0.0;
-    public double launcherAppliedVolts = 0.0;
-    public double launcherCurrentAmps = 0.0;
+    public double launcherRPM;
+    public double launcherAppliedVolts;
+    public double launcherCurrentAmps;
 
     // launcher, pivot
     public double[] tempsCelcius = new double[2];
@@ -30,7 +30,7 @@ public interface ShooterIO {
   /** Updates the set of loggable inputs. */
   public default void updateInputs(Inputs inputs) {}
 
-  // PIVOT
+  // Pivot
   public default void setPivotPosition(Rotation2d rot) {}
 
   public default void setPivotVoltage(double volts) {}
@@ -40,13 +40,13 @@ public interface ShooterIO {
   public default void setPivotClosedLoopConstants(
       double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {}
 
-  // LAUNCHER
+  // Launcher
   public default void setLauncherVoltage(double volts) {}
 
   public default void setLauncherRPM(double rollerRPM) {}
 
   public default void setLauncherClosedLoopConstants(
-      double kP, double kV, double kS, double maxProfiledAcceleration) {}
+      double kP, double kV, double kS, double targetAccelerationConfig) {}
 
   public default boolean setNeutralMode(NeutralModeValue value) {
     return false;

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.shooter;
 
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.lib.team2930.LoggerGroup;
@@ -37,11 +38,7 @@ public interface ShooterIO {
   public default void resetPivotSensorPosition(Rotation2d position) {}
 
   public default void setPivotClosedLoopConstants(
-      double kP,
-      double kD,
-      double kG,
-      double maxProfiledVelocity,
-      double maxProfiledAcceleration) {}
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {}
 
   // LAUNCHER
   public default void setLauncherVoltage(double volts) {}

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOReal.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOReal.java
@@ -177,23 +177,18 @@ public class ShooterIOReal implements ShooterIO {
 
   @Override
   public void setPivotClosedLoopConstants(
-      double kP, double kD, double kG, double maxProfiledVelocity, double maxProfiledAcceleration) {
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {
     Slot0Configs pidConfig = new Slot0Configs();
-    MotionMagicConfigs mmConfig = new MotionMagicConfigs();
 
     var configurator = pivot.getConfigurator();
     configurator.refresh(pidConfig);
-    configurator.refresh(mmConfig);
 
     pidConfig.kP = kP;
     pidConfig.kD = kD;
     pidConfig.kG = kG;
 
-    mmConfig.MotionMagicCruiseVelocity = maxProfiledVelocity;
-    mmConfig.MotionMagicAcceleration = maxProfiledAcceleration;
-
     configurator.apply(pidConfig);
-    configurator.apply(mmConfig);
+    configurator.apply(mmConfigs);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOReal.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOReal.java
@@ -15,14 +15,17 @@ import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.units.Units;
 import frc.robot.Constants;
+import frc.robot.Constants.MotorConstants.KrakenConstants;
 import frc.robot.Constants.ShooterConstants;
+import frc.robot.Constants.ShooterConstants.LauncherConstants;
+import frc.robot.Constants.ShooterConstants.PivotConstants;
 
 public class ShooterIOReal implements ShooterIO {
 
-  TalonFX launcher = new TalonFX(Constants.CanIDs.SHOOTER_CAN_ID);
-  TalonFX pivot = new TalonFX(Constants.CanIDs.SHOOTER_PIVOT_CAN_ID);
-  TalonFX kicker = new TalonFX(Constants.CanIDs.SHOOTER_KICKER_CAN_ID);
+  private final TalonFX launcher = new TalonFX(Constants.CanIDs.SHOOTER_CAN_ID);
+  private final TalonFX pivot = new TalonFX(Constants.CanIDs.SHOOTER_PIVOT_CAN_ID);
 
   private final StatusSignal<Double> pivotPosition;
   private final StatusSignal<Double> pivotVelocity;
@@ -46,49 +49,48 @@ public class ShooterIOReal implements ShooterIO {
       new MotionMagicVelocityVoltage(0.0).withEnableFOC(true);
   private final VoltageOut launcherOpenLoop = new VoltageOut(0.0).withEnableFOC(true);
 
-  private final MotionMagicVelocityVoltage kickerClosedLoop =
-      new MotionMagicVelocityVoltage(0, 0, true, 0, 0, false, false, false);
-
   public ShooterIOReal() {
-    // --- launcher config ---
+    // Launcher config
     TalonFXConfiguration launcherConfig = new TalonFXConfiguration();
 
-    // FIXME: get true current limits
-    launcherConfig.CurrentLimits.SupplyCurrentLimit = 40;
-    launcherConfig.CurrentLimits.SupplyCurrentThreshold = 60.0;
-    launcherConfig.CurrentLimits.SupplyTimeThreshold = 0.1;
+    launcherConfig.CurrentLimits.SupplyCurrentLimit = LauncherConstants.SUPPLY_CURRENT_LIMIT;
+    launcherConfig.CurrentLimits.SupplyCurrentThreshold =
+        LauncherConstants.SUPPLY_CURRENT_THRESHOLD;
+    launcherConfig.CurrentLimits.SupplyTimeThreshold = LauncherConstants.SUPPLY_TIME_THRESHOLD;
     launcherConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
     launcherConfig.MotorOutput.NeutralMode = NeutralModeValue.Coast;
     launcherConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
-    launcherConfig.Feedback.SensorToMechanismRatio = ShooterConstants.Launcher.GEARING;
+    launcherConfig.Feedback.SensorToMechanismRatio = ShooterConstants.LauncherConstants.GEARING;
 
     launcherConfig.Voltage.PeakReverseVoltage = 0.0;
-    launcherConfig.Voltage.SupplyVoltageTimeConstant = 0.02;
+    launcherConfig.Voltage.SupplyVoltageTimeConstant = KrakenConstants.SUPPLY_VOLTAGE_TIME;
 
     launcher.getConfigurator().apply(launcherConfig);
 
-    // --- pivot config ---
+    // Pivot config
     TalonFXConfiguration pivotConfig = new TalonFXConfiguration();
 
-    pivotConfig.CurrentLimits.SupplyCurrentLimit = 40;
-    pivotConfig.CurrentLimits.SupplyCurrentThreshold = 60.0;
-    pivotConfig.CurrentLimits.SupplyTimeThreshold = 0.1;
+    pivotConfig.CurrentLimits.SupplyCurrentLimit = PivotConstants.SUPPLY_CURRENT_LIMIT;
+    pivotConfig.CurrentLimits.SupplyCurrentThreshold = PivotConstants.SUPPLY_CURRENT_THRESHOLD;
+    pivotConfig.CurrentLimits.SupplyTimeThreshold = PivotConstants.SUPPLY_TIME_THRESHOLD;
     pivotConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
 
-    pivotConfig.Feedback.SensorToMechanismRatio = Constants.ShooterConstants.Pivot.GEARING;
+    pivotConfig.Feedback.SensorToMechanismRatio = PivotConstants.GEARING;
     pivotConfig.Slot0.GravityType = GravityTypeValue.Arm_Cosine;
     pivotConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
     pivotConfig.SoftwareLimitSwitch.ForwardSoftLimitThreshold =
-        Constants.ShooterConstants.Pivot.MAX_ANGLE_RAD.getRotations();
+        PivotConstants.MAX_ANGLE_RAD.getRotations();
     pivotConfig.SoftwareLimitSwitch.ReverseSoftLimitThreshold =
-        Constants.ShooterConstants.Pivot.MIN_ANGLE_RAD.getRotations();
+        PivotConstants.MIN_ANGLE_RAD.getRotations();
 
     pivotConfig.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
     pivotConfig.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
 
     pivot.getConfigurator().apply(pivotConfig);
+
+    // Pivot status signals
 
     pivotPosition = pivot.getPosition();
     pivotVelocity = pivot.getVelocity();
@@ -96,10 +98,14 @@ public class ShooterIOReal implements ShooterIO {
     pivotCurrentAmps = pivot.getStatorCurrent();
     pivotTempCelsius = pivot.getDeviceTemp();
 
+    // Launcher status signals
+
     launcherVelocity = launcher.getVelocity();
     launcherVoltage = launcher.getMotorVoltage();
     launcherCurrentAmps = launcher.getStatorCurrent();
     launcherTempCelsius = launcher.getDeviceTemp();
+
+    // Update status signals
 
     BaseStatusSignal.setUpdateFrequencyForAll(100, pivotPosition, launcherVelocity);
     BaseStatusSignal.setUpdateFrequencyForAll(50, pivotVelocity, pivotVoltage, pivotCurrentAmps);
@@ -108,7 +114,6 @@ public class ShooterIOReal implements ShooterIO {
 
     launcher.optimizeBusUtilization();
     pivot.optimizeBusUtilization();
-    kicker.optimizeBusUtilization();
 
     refreshSet =
         new BaseStatusSignal[] {
@@ -130,14 +135,14 @@ public class ShooterIOReal implements ShooterIO {
     inputs.refreshAll(refreshSet);
 
     inputs.pivotPosition = Rotation2d.fromRotations(pivotPosition.getValueAsDouble());
-    // rotations to rads = mult by 2pi. 1 full rot = 2pi rads
-    inputs.pivotVelocityRadsPerSec = pivotVelocity.getValueAsDouble() * (2 * Math.PI);
+    inputs.pivotVelocityDegreesPerSec =
+        Units.RotationsPerSecond.of(pivotVelocity.getValueAsDouble()).in(Units.DegreesPerSecond);
     inputs.pivotAppliedVolts = pivotVoltage.getValueAsDouble();
     inputs.pivotCurrentAmps = pivotCurrentAmps.getValueAsDouble();
 
-    inputs.launcherRPM = launcherVelocity.getValueAsDouble() * 60.0;
+    inputs.launcherRPM =
+        Units.RotationsPerSecond.of(launcherVelocity.getValueAsDouble()).in(Units.RPM);
 
-    // rps to rpm = mult by 60
     inputs.launcherAppliedVolts = launcherVoltage.getValueAsDouble();
 
     inputs.launcherCurrentAmps = launcherCurrentAmps.getValueAsDouble();
@@ -193,7 +198,7 @@ public class ShooterIOReal implements ShooterIO {
 
   @Override
   public void setLauncherClosedLoopConstants(
-      double kP, double kV, double kS, double maxProfiledAcceleration) {
+      double kP, double kV, double kS, double targetAccelerationConfig) {
     Slot0Configs pidConfig = new Slot0Configs();
     MotionMagicConfigs mmConfig = new MotionMagicConfigs();
 
@@ -206,7 +211,7 @@ public class ShooterIOReal implements ShooterIO {
     pidConfig.kV = kV;
     pidConfig.kS = kS;
 
-    mmConfig.MotionMagicAcceleration = maxProfiledAcceleration;
+    mmConfig.MotionMagicAcceleration = targetAccelerationConfig;
 
     leadConfigurator.apply(pidConfig);
     leadConfigurator.apply(mmConfig);

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
@@ -23,13 +23,13 @@ public class ShooterIOSim implements ShooterIO {
       new TalonFXArmSim(
           new SingleJointedArmSim(
               DCMotor.getFalcon500Foc(1),
-              ShooterConstants.Pivot.GEARING,
+              ShooterConstants.PivotConstants.GEARING,
               SingleJointedArmSim.estimateMOI(Units.Feet.of(1.5).in(Units.Meters), 20.0),
               ShooterConstants.SHOOTER_LENGTH.in(Units.Meters),
-              ShooterConstants.Pivot.MIN_ANGLE_RAD.getRadians(),
-              ShooterConstants.Pivot.MAX_ANGLE_RAD.getRadians(),
+              ShooterConstants.PivotConstants.MIN_ANGLE_RAD.getRadians(),
+              ShooterConstants.PivotConstants.MAX_ANGLE_RAD.getRadians(),
               false,
-              ShooterConstants.Pivot.SIM_INITIAL_ANGLE));
+              ShooterConstants.PivotConstants.SIM_INITIAL_ANGLE));
 
   private VoltageOut pivotOpenLoopControl = new VoltageOut(0);
   private MotionMagicVoltage pivotClosedLoopControl = new MotionMagicVoltage(0);
@@ -39,8 +39,8 @@ public class ShooterIOSim implements ShooterIO {
   private final TalonFXSim launcher =
       new TalonFXSim(
           DCMotor.getFalcon500Foc(2),
-          ShooterConstants.Launcher.GEARING,
-          ShooterConstants.Launcher.MOI);
+          ShooterConstants.LauncherConstants.GEARING,
+          ShooterConstants.LauncherConstants.MOI);
 
   private VoltageOut launcherOpenLoopControl = new VoltageOut(0);
   private VelocityVoltage launcherClosedLoopControl = new VelocityVoltage(0);
@@ -57,7 +57,7 @@ public class ShooterIOSim implements ShooterIO {
     // Pivot inputs
 
     inputs.pivotAppliedVolts = pivot.getVoltage();
-    inputs.pivotVelocityRadsPerSec = pivot.getVelocity().in(Units.RadiansPerSecond);
+    inputs.pivotVelocityDegreesPerSec = pivot.getVelocity().in(Units.DegreesPerSecond);
     inputs.pivotPosition = new Rotation2d(pivot.getPosition());
 
     // Launcher inputs

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
@@ -1,137 +1,123 @@
 package frc.robot.subsystems.shooter;
 
-import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.ProfiledPIDController;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.Units;
-import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
-import frc.lib.team2930.LoggerEntry;
+import frc.lib.team2930.TalonFXArmSim;
+import frc.lib.team2930.TalonFXSim;
 import frc.robot.Constants;
-import frc.robot.Constants.ControlMode;
+import frc.robot.Constants.ShooterConstants;
 
 public class ShooterIOSim implements ShooterIO {
-  public static final LoggerEntry.Decimal log_error = Shooter.logGroup.buildDecimal("SIM_error");
-  public static final LoggerEntry.Decimal log_feedForward =
-      Shooter.logGroup.buildDecimal("SIM_feedForward");
-  public static final LoggerEntry.Decimal log_outputVoltage =
-      Shooter.logGroup.buildDecimal("SIM_outputVoltage");
-  public static final LoggerEntry.Decimal log_targetVelRadPerSec =
-      Shooter.logGroup.buildDecimal("SIM_targetVelRadPerSec");
-  public static final LoggerEntry.Decimal log_currentVelRadPerSec =
-      Shooter.logGroup.buildDecimal("SIM_currentVelRadPerSec");
-  public static final LoggerEntry.Decimal log_pitchController =
-      Shooter.logGroup.buildDecimal("SIM_pitchController");
-  public static final LoggerEntry.EnumValue<ControlMode> log_pivotControlMode =
-      Shooter.logGroup.buildEnum("SIM_pivotControlMode");
-  public static final LoggerEntry.Decimal log_targetPositionDegrees =
-      Shooter.logGroup.buildDecimal("SIM_targetPositionDegrees");
 
-  private final SingleJointedArmSim pivot =
-      new SingleJointedArmSim(
-          DCMotor.getFalcon500Foc(1),
-          Constants.ShooterConstants.Pivot.GEARING,
-          SingleJointedArmSim.estimateMOI(Units.Feet.of(1.5).in(Units.Meters), 20.0),
-          Constants.ShooterConstants.SHOOTER_LENGTH.in(Units.Meters),
-          Constants.ShooterConstants.Pivot.MIN_ANGLE_RAD.getRadians(),
-          Constants.ShooterConstants.Pivot.MAX_ANGLE_RAD.getRadians(),
-          false,
-          Constants.ShooterConstants.Pivot.SIM_INITIAL_ANGLE);
+  // Pivot objects
 
-  private final DCMotorSim launcherMotorSim =
-      new DCMotorSim(
+  private final TalonFXArmSim pivot =
+      new TalonFXArmSim(
+          new SingleJointedArmSim(
+              DCMotor.getFalcon500Foc(1),
+              ShooterConstants.Pivot.GEARING,
+              SingleJointedArmSim.estimateMOI(Units.Feet.of(1.5).in(Units.Meters), 20.0),
+              ShooterConstants.SHOOTER_LENGTH.in(Units.Meters),
+              ShooterConstants.Pivot.MIN_ANGLE_RAD.getRadians(),
+              ShooterConstants.Pivot.MAX_ANGLE_RAD.getRadians(),
+              false,
+              ShooterConstants.Pivot.SIM_INITIAL_ANGLE));
+
+  private VoltageOut pivotOpenLoopControl = new VoltageOut(0);
+  private MotionMagicVoltage pivotClosedLoopControl = new MotionMagicVoltage(0);
+
+  // Launcher objects
+
+  private final TalonFXSim launcher =
+      new TalonFXSim(
           DCMotor.getFalcon500Foc(2),
-          Constants.ShooterConstants.Launcher.GEARING,
-          Constants.ShooterConstants.Launcher.MOI);
+          ShooterConstants.Launcher.GEARING,
+          ShooterConstants.Launcher.MOI);
 
-  private final ProfiledPIDController pivotFeedback =
-      new ProfiledPIDController(50.0, 0, 0.0, new Constraints(5, 10.0));
-
-  private final PIDController pivotVelController = new PIDController(60, 0, 0);
-  private final double pivotTargetVelRadPerSec = 0.0;
-  private ControlMode pivotControlMode = ControlMode.VELOCITY;
-  private Rotation2d pivotClosedLoopTargetAngle = Constants.zeroRotation2d;
-  private double pivotControlEffort = 0.0;
-  private double pivotOpenLoopVolts = 0.0;
-
-  private double launcherOpenLoopVolts = 0.0;
-
-  private double targetRPM = 0.0;
+  private VoltageOut launcherOpenLoopControl = new VoltageOut(0);
+  private VelocityVoltage launcherClosedLoopControl = new VelocityVoltage(0);
 
   public ShooterIOSim() {}
 
   @Override
   public void updateInputs(Inputs inputs) {
 
+    // Update simulations
     pivot.update(Constants.kDefaultPeriod);
-    launcherMotorSim.update(Constants.kDefaultPeriod);
+    launcher.update(Constants.kDefaultPeriod);
 
-    pivotFeedback.setTolerance(1.0);
+    // Pivot inputs
 
-    inputs.pivotPosition = new Rotation2d(pivot.getAngleRads());
+    inputs.pivotAppliedVolts = pivot.getVoltage();
+    inputs.pivotVelocityRadsPerSec = pivot.getVelocity().in(Units.RadiansPerSecond);
+    inputs.pivotPosition = new Rotation2d(pivot.getPosition());
 
-    inputs.launcherRPM = targetRPM;
+    // Launcher inputs
 
-    double ff = 0.0;
+    inputs.launcherAppliedVolts = launcher.getVoltage();
+    inputs.launcherRPM = launcher.getVelocity().in(Units.RPM);
+  }
 
-    if (pivotControlMode.equals(ControlMode.POSITION)) {
+  // Pivot Methods
 
-      pivotControlEffort =
-          pivotFeedback.calculate(
-                  inputs.pivotPosition.getRadians(), pivotClosedLoopTargetAngle.getRadians())
-              + ff;
-
-      log_error.info(pivotFeedback.getPositionError());
-    } else if (pivotControlMode.equals(ControlMode.VELOCITY)) {
-
-      pivotControlEffort =
-          pivotVelController.calculate(pivot.getVelocityRadPerSec(), pivotTargetVelRadPerSec) + ff;
-
-    } else {
-
-      pivotControlEffort = pivotOpenLoopVolts;
-    }
-
-    log_feedForward.info(ff);
-
-    launcherMotorSim.setInputVoltage(launcherOpenLoopVolts);
-
-    pivot.setInputVoltage(MathUtil.clamp(pivotControlEffort, -12.0, 12.0));
-    log_outputVoltage.info(MathUtil.clamp(pivotControlEffort, -12.0, 12.0));
-    log_targetVelRadPerSec.info(pivotTargetVelRadPerSec);
-    log_currentVelRadPerSec.info(pivot.getVelocityRadPerSec());
-    log_pitchController.info(
-        pivotVelController.calculate(pivot.getVelocityRadPerSec(), pivotTargetVelRadPerSec));
-    log_pivotControlMode.info(pivotControlMode);
-    log_targetPositionDegrees.info(pivotClosedLoopTargetAngle.getDegrees());
+  @Override
+  public void setPivotVoltage(double volts) {
+    pivot.setControl(pivotOpenLoopControl.withOutput(volts));
   }
 
   @Override
   public void setPivotPosition(Rotation2d rot) {
-    pivotClosedLoopTargetAngle = rot;
-    pivotControlMode = ControlMode.POSITION;
+    pivot.setControl(pivotClosedLoopControl.withPosition(rot.getRotations()));
   }
 
   @Override
   public void setPivotClosedLoopConstants(
-      double kP, double kD, double kG, double maxProfiledVelocity, double maxProfiledAcceleration) {
+      double kP, double kD, double kG, MotionMagicConfigs mmConfigs) {
+    TalonFXConfiguration config = new TalonFXConfiguration();
+    Slot0Configs slot0Configs = new Slot0Configs();
 
-    pivotFeedback.setP(kP);
-    pivotFeedback.setD(kD);
-    pivotFeedback.setConstraints(new Constraints(maxProfiledVelocity, maxProfiledAcceleration));
+    slot0Configs.kP = kP;
+    slot0Configs.kD = kD;
+    slot0Configs.kG = kG;
+
+    config.Slot0 = slot0Configs;
+    config.MotionMagic = mmConfigs;
+
+    pivot.setConfig(config);
   }
 
-  @Override
-  public void setPivotVoltage(double volts) {
-    pivotOpenLoopVolts = volts;
-    pivotControlMode = ControlMode.VOLTAGE;
-  }
+  // Launcher Methods
 
   @Override
   public void setLauncherVoltage(double volts) {
-    launcherOpenLoopVolts = volts;
+    launcher.setControl(launcherOpenLoopControl.withOutput(volts));
+  }
+
+  @Override
+  public void setLauncherRPM(double rollerRPM) {
+    launcher.setControl(launcherClosedLoopControl.withVelocity(rollerRPM));
+  }
+
+  @Override
+  public void setLauncherClosedLoopConstants(
+      double kP, double kV, double kS, double maxProfiledAcceleration) {
+    TalonFXConfiguration config = new TalonFXConfiguration();
+    Slot0Configs slot0Configs = new Slot0Configs();
+
+    slot0Configs.kP = kP;
+    slot0Configs.kV = kV;
+    slot0Configs.kS = kS;
+
+    config.Slot0 = slot0Configs;
+
+    launcher.setConfig(config);
   }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/DrivetrainWrapper.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DrivetrainWrapper.java
@@ -10,6 +10,8 @@ import frc.lib.team2930.LoggerEntry;
 import frc.lib.team2930.LoggerGroup;
 
 public class DrivetrainWrapper {
+
+  // Logging
   private static final LoggerGroup logGroup = LoggerGroup.build("DrivetrainWrapper");
   private static final LoggerEntry.Struct<ChassisSpeeds> logChassisSpeedsBase =
       logGroup.buildStruct(ChassisSpeeds.class, "chassisSpeedsBase");
@@ -28,32 +30,7 @@ public class DrivetrainWrapper {
     this.drivetrain = drivetrain;
   }
 
-  /**
-   * Sets robot-centric chassis speeds
-   *
-   * @param chassisSpeeds speeds (m/s, rad/s)
-   */
-  public void setVelocity(ChassisSpeeds chassisSpeeds) {
-    if (chassisSpeeds == null) chassisSpeeds = new ChassisSpeeds();
-    chassisSpeedsBase = chassisSpeeds;
-  }
-
-  public void setVelocityOverride(ChassisSpeeds chassisSpeeds) {
-    chassisSpeedsOverride = chassisSpeeds;
-  }
-
-  public void resetVelocityOverride() {
-    chassisSpeedsOverride = null;
-  }
-
-  public void setRotationOverride(double omega) {
-    omegaOverride = omega;
-  }
-
-  public void resetRotationOverride() {
-    omegaOverride = Double.NaN;
-  }
-
+  /** Updated periodically, updates swerve state. */
   public void apply() {
     if (chassisSpeedsBase != null) {
       logChassisSpeedsBase.info(chassisSpeedsBase);
@@ -90,6 +67,47 @@ public class DrivetrainWrapper {
     logGyroDrift.info(pose1.getRotation().minus(pose2.getRotation()));
   }
 
+  // Setters
+
+  /**
+   * Sets robot-centric chassis speeds
+   *
+   * @param chassisSpeeds speeds (m/s, rad/s)
+   */
+  public void setVelocity(ChassisSpeeds chassisSpeeds) {
+    if (chassisSpeeds == null) chassisSpeeds = new ChassisSpeeds();
+    chassisSpeedsBase = chassisSpeeds;
+  }
+
+  public void setVelocityOverride(ChassisSpeeds chassisSpeeds) {
+    chassisSpeedsOverride = chassisSpeeds;
+  }
+
+  public void resetVelocityOverride() {
+    chassisSpeedsOverride = null;
+  }
+
+  public void setRotationOverride(double omega) {
+    omegaOverride = omega;
+  }
+
+  public void resetRotationOverride() {
+    omegaOverride = Double.NaN;
+  }
+
+  public SysIdRoutine.Mechanism getSysIdMechanism() {
+    return new SysIdRoutine.Mechanism(
+        (voltage) -> drivetrain.runCharacterizationVolts(voltage.in(Units.Volts)),
+        null, // No log consumer, since data is recorded by AdvantageKit
+        drivetrain);
+  }
+
+  public void setPose(Pose2d pose) {
+    drivetrain.setPose(pose);
+  }
+
+  // Getters
+
   public Subsystem getRequirements() {
     return drivetrain;
   }
@@ -125,16 +143,5 @@ public class DrivetrainWrapper {
 
   public Rotation2d getRotationGyroOnly() {
     return drivetrain.getRotationGyroOnly();
-  }
-
-  public SysIdRoutine.Mechanism getSysIdMechanism() {
-    return new SysIdRoutine.Mechanism(
-        (voltage) -> drivetrain.runCharacterizationVolts(voltage.in(Units.Volts)),
-        null, // No log consumer, since data is recorded by AdvantageKit
-        drivetrain);
-  }
-
-  public void setPose(Pose2d pose) {
-    drivetrain.setPose(pose);
   }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class SwerveModule {
   public static final int ODOMETRY_FREQUENCY = 250;
 
+  // Logging
   public static final TunableNumberGroup group = new TunableNumberGroup("RobotConfig");
   public static final LoggedTunableNumber turnCruiseVelocity =
       group.build("SwerveTurnCruiseVelocity", 200);
@@ -51,6 +52,7 @@ public class SwerveModule {
   private final SwerveModuleIO.Inputs inputs;
   private final double wheelRadius;
 
+  // Tunable numbers
   private final LoggedTunableNumber driveKS;
   private final LoggedTunableNumber driveKV;
   private final LoggedTunableNumber driveKA;
@@ -68,6 +70,8 @@ public class SwerveModule {
   public SwerveModule(int index, RobotConfig config, SwerveModuleIO io) {
     this.io = io;
 
+    // Logging
+
     String key = "SwerveModule" + index;
     var group = LoggerGroup.build(key);
     log_drivePositionRad = group.buildDecimal("DrivePositionRad");
@@ -84,6 +88,8 @@ public class SwerveModule {
     inputs = new SwerveModuleIO.Inputs(group);
 
     wheelRadius = config.getWheelRadius().in(Units.Meters);
+
+    // Tunable numbers
 
     driveKS = config.getDriveKS();
     driveKV = config.getDriveKV();
@@ -115,6 +121,7 @@ public class SwerveModule {
 
   public void periodic() {
     try (var ignored = timing.start()) {
+      // Logging
       log_drivePositionRad.info(inputs.drivePositionRad);
       log_driveVelocityRadPerSec.info(inputs.driveVelocityRadPerSec);
       log_driveAppliedVolts.info(inputs.driveAppliedVolts);
@@ -167,6 +174,8 @@ public class SwerveModule {
     return io.updateOdometry(inputs, wheelRadius);
   }
 
+  // Setters
+
   /** Runs the module with the specified setpoint state. Returns the optimized state. */
   public SwerveModuleState runSetpoint(
       SwerveModuleState state, double driveMotorMotionMagicAcceleration) {
@@ -205,6 +214,8 @@ public class SwerveModule {
     io.setTurnBrakeMode(enabled);
   }
 
+  // Getters
+
   /** Returns the current turn angle of the module. */
   public Rotation2d getAngle() {
     return inputs.angle;
@@ -233,11 +244,6 @@ public class SwerveModule {
   /** Returns the drive velocity in radians/sec. */
   public double getCharacterizationVelocity() {
     return inputs.driveVelocityRadPerSec;
-  }
-
-  public void getCurrentAmps(double[] array, int offset) {
-    array[offset] = inputs.driveCurrentAmps;
-    array[offset + 1] = inputs.turnCurrentAmps;
   }
 
   public double getAppliedVoltage() {

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIOSim.java
@@ -23,7 +23,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import frc.robot.Constants;
-import frc.robot.configs.RobotConfig2024;
+import frc.robot.configs.RobotConfig2024Maestro;
 import java.util.List;
 
 /**
@@ -37,9 +37,11 @@ public class SwerveModuleIOSim implements SwerveModuleIO {
   private static final double LOOP_PERIOD_SECS = Constants.kDefaultPeriod;
 
   private final DCMotorSim driveSim =
-      new DCMotorSim(DCMotor.getKrakenX60(1), RobotConfig2024.SWERVE_DRIVE_GEAR_RATIO, 0.025);
+      new DCMotorSim(
+          DCMotor.getKrakenX60(1), RobotConfig2024Maestro.SWERVE_DRIVE_GEAR_RATIO, 0.025);
   private final DCMotorSim turnSim =
-      new DCMotorSim(DCMotor.getFalcon500(1), RobotConfig2024.SWERVE_STEER_GEAR_RATIO, 0.004);
+      new DCMotorSim(
+          DCMotor.getFalcon500(1), RobotConfig2024Maestro.SWERVE_STEER_GEAR_RATIO, 0.004);
 
   private final SimpleMotorFeedforward driveFeedforward;
   private final PIDController driveFeedback;

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModules.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModules.java
@@ -68,15 +68,6 @@ public class SwerveModules {
     return driveVelocityAverage / 4;
   }
 
-  public double[] getCurrentDrawAmps() {
-    double[] current = new double[8];
-    front_left.getCurrentAmps(current, 0);
-    front_right.getCurrentAmps(current, 2);
-    back_left.getCurrentAmps(current, 4);
-    back_right.getCurrentAmps(current, 6);
-    return current;
-  }
-
   public void registerSignalForOdometry(List<BaseStatusSignal> signals) {
     front_left.registerSignalForOdometry(signals);
     front_right.registerSignalForOdometry(signals);

--- a/src/main/java/frc/robot/subsystems/swerve/gyro/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/gyro/GyroIOPigeon2.java
@@ -35,6 +35,7 @@ public class GyroIOPigeon2 implements GyroIO {
   private final BaseStatusSignal[] refreshSet;
 
   public GyroIOPigeon2(RobotConfig config, int canID) {
+    // Pigeon config
     Pigeon2Configuration pigeonConfig = new Pigeon2Configuration();
     pigeonConfig.MountPose.MountPosePitch = config.getGyroMountingPitch();
     pigeonConfig.MountPose.MountPoseRoll = config.getGyroMountingRoll();
@@ -44,13 +45,16 @@ public class GyroIOPigeon2 implements GyroIO {
 
     pigeon.getConfigurator().apply(pigeonConfig);
 
+    // Status signals
+
     yaw = pigeon.getYaw();
-    // FIXME: is this the correct method call
     yawVelocity = pigeon.getAngularVelocityZDevice();
 
     xAcceleration = pigeon.getAccelerationX();
     yAcceleration = pigeon.getAccelerationY();
     zAcceleration = pigeon.getAccelerationZ();
+
+    // Update status signals
 
     pigeon.getConfigurator().apply(new Pigeon2Configuration());
     pigeon.getConfigurator().setYaw(0.0);

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -30,6 +30,8 @@ public class Vision extends SubsystemBase {
 
   private static final ExecutionTiming timing = new ExecutionTiming(ROOT_TABLE);
 
+  // Logging
+
   public static final LoggerGroup logGroup = LoggerGroup.build(ROOT_TABLE);
   private static final LoggerEntry.StructArray<Pose3d> logAllAprilTags3D =
       logGroup.buildStructArray(Pose3d.class, "AllAprilTags3D");
@@ -56,6 +58,8 @@ public class Vision extends SubsystemBase {
       logGroupVisibleTags.buildStructArray(Pose3d.class, "posesFedToPoseEstimator3D");
   private static final LoggerEntry.StructArray<Pose2d> log_posesFedToPoseEstimator2D =
       logGroupVisibleTags.buildStructArray(Pose2d.class, "posesFedToPoseEstimator2D");
+
+  // Tunable numbers
 
   protected static final TunableNumberGroup group = new TunableNumberGroup("Vision");
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionModule.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionModule.java
@@ -26,6 +26,8 @@ public class VisionModule {
 
   public final Alert missingCameraAlert;
 
+  // Logging
+
   public final LoggerEntry.ByteArray log_photonPacketBytes;
   public final LoggerEntry.Decimal log_lastTimestampCTRETime;
   public final LoggerEntry.Bool log_connected;
@@ -70,6 +72,8 @@ public class VisionModule {
     photonPoseEstimator.setMultiTagFallbackStrategy(PoseStrategy.CLOSEST_TO_CAMERA_HEIGHT);
 
     this.missingCameraAlert = new Alert("Missing Camera: " + this.name, Alert.AlertType.ERROR);
+
+    // Logging
 
     logGroup = logGroup.subgroup(name);
 
@@ -119,6 +123,8 @@ public class VisionModule {
     for (int i = 0; i < fieldsToLog.seenTags().length; i++) {
       seenTagsArray[i] = fieldsToLog.seenTags()[i];
     }
+
+    // Logging
 
     log_status.info(status.name());
     log_cameraPose.info(robotPose.transformBy(RobotToCamera));

--- a/src/main/java/frc/robot/subsystems/visionGamepiece/ProcessedGamepieceData.java
+++ b/src/main/java/frc/robot/subsystems/visionGamepiece/ProcessedGamepieceData.java
@@ -11,43 +11,41 @@ import frc.robot.Constants;
 import frc.robot.Constants.FieldConstants.Gamepieces;
 
 public class ProcessedGamepieceData {
-  private Rotation2d targetYaw;
-  private Rotation2d targetPitch;
-  private double distance;
-  private Pose2d pose;
   public Pose2d globalPose;
   public double timestamp_RIOFPGA_capture;
 
-  public ProcessedGamepieceData(
-      Rotation2d targetYaw,
-      Rotation2d targetPitch,
-      double distance,
-      Pose2d pose,
-      Pose2d globalPose,
-      double timestamp_RIOFPGA_capture) {
-    this.targetYaw = targetYaw;
-    this.targetPitch = targetPitch;
-    this.distance = distance;
-    this.pose = pose;
+  public ProcessedGamepieceData(Pose2d globalPose, double timestamp_RIOFPGA_capture) {
     this.globalPose = globalPose;
     this.timestamp_RIOFPGA_capture = timestamp_RIOFPGA_capture;
   }
 
+  /**
+   * @param pose current global pose
+   */
   public Pose2d getRobotCentricPose(Pose2d pose) {
     return globalPose.relativeTo(pose);
   }
 
+  /**
+   * @param pose current global pose
+   */
   public Rotation2d getYaw(Pose2d pose) {
     Pose2d relativePose = getRobotCentricPose(pose);
     return Rotation2d.fromRadians(Math.atan2(relativePose.getY(), relativePose.getX()));
   }
 
+  /**
+   * @param pose current global pose
+   */
   public Rotation2d getPitch(Pose2d pose) {
     double distance = getDistance(pose).in(Units.Meters);
     double height = Constants.VisionGamepieceConstants.GAMEPIECE_CAMERA_POSE.getZ();
     return Rotation2d.fromRadians(Math.atan2(height, distance));
   }
 
+  /**
+   * @param pose current global pose
+   */
   public Measure<Distance> getDistance(Pose2d pose) {
     return Units.Meters.of(GeometryUtil.getDist(globalPose, pose));
   }

--- a/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIO.java
+++ b/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIO.java
@@ -3,15 +3,15 @@ package frc.robot.subsystems.visionGamepiece;
 public interface VisionGamepieceIO {
 
   public static class Inputs {
-    public boolean isConnected = false;
-    public boolean validTarget = false;
-    public double totalLatencyMs = 0;
-    public double timestamp = 0.0;
+    public boolean isConnected;
+    public boolean validTarget;
+    public double totalLatencyMs;
+    public double timestamp;
     public double[] pitch = new double[] {};
     public double[] yaw = new double[] {};
     public double[] area = new double[] {};
-    public int targetCount = 0;
-    public double aprilTagYaw = 0.0;
+    public int targetCount;
+    public double aprilTagYaw;
     public int pipelineIndex;
   }
 

--- a/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIOReal.java
+++ b/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIOReal.java
@@ -1,8 +1,6 @@
 package frc.robot.subsystems.visionGamepiece;
 
 import com.ctre.phoenix6.Utils;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Timer;
 import frc.robot.Constants;
 import java.util.List;
@@ -50,15 +48,14 @@ public class VisionGamepieceIOReal implements VisionGamepieceIO {
 
     inputs.timestamp = timestamp;
 
+    // April tag code (for if gamepiece camera is to be used for april tag detection)
+
     var aprilTagYaw = 0.0;
-    for (int i = 0; i < results.getTargets().size(); i++) {
+    for (int i = 0;
+        i < results.getTargets().size();
+        i++) { // TODO: implement logic for what april tags to detect if necessary
       PhotonTrackedTarget target = results.targets.get(i);
-      if ((DriverStation.getAlliance().get().equals(Alliance.Red)
-              && (target.getFiducialId() >= 11 && target.getFiducialId() <= 13))
-          || (DriverStation.getAlliance().get().equals(Alliance.Blue)
-              && (target.getFiducialId() >= 14 && target.getFiducialId() <= 16))) {
-        aprilTagYaw = target.getYaw();
-      }
+      aprilTagYaw = target.getYaw();
     }
 
     inputs.aprilTagYaw = aprilTagYaw;

--- a/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIOSim.java
+++ b/src/main/java/frc/robot/subsystems/visionGamepiece/VisionGamepieceIOSim.java
@@ -2,16 +2,13 @@ package frc.robot.subsystems.visionGamepiece;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.units.Units;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import frc.robot.Constants;
+import frc.robot.Constants.VisionGamepieceConstants;
 import frc.robot.configs.RobotConfig;
 import java.util.function.Supplier;
-import org.littletonrobotics.junction.Logger;
 import org.photonvision.PhotonCamera;
 import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.SimCameraProperties;
@@ -26,16 +23,22 @@ public class VisionGamepieceIOSim implements VisionGamepieceIO {
 
   private final Supplier<Pose2d> poseSupplier;
 
+  /** Designed for simulated april tag detection of gamepiece camera */
   public VisionGamepieceIOSim(RobotConfig config, Supplier<Pose2d> poseSupplier) {
 
     this.poseSupplier = poseSupplier;
     var cameraProp = new SimCameraProperties();
     // FIXME: get these values for the cameras we use
-    cameraProp.setCalibration(960, 720, Rotation2d.fromDegrees(128.2));
-    cameraProp.setCalibError(0.35, 0.10);
-    cameraProp.setFPS(15);
-    cameraProp.setAvgLatencyMs(25);
-    cameraProp.setLatencyStdDevMs(10);
+    cameraProp.setCalibration(
+        VisionGamepieceConstants.RESOLUTION_WIDTH_PIXELS,
+        VisionGamepieceConstants.RESOLUTION_HEIGHT_PIXELS,
+        VisionGamepieceConstants.FOV_DIAGONAL);
+    cameraProp.setCalibError(
+        VisionGamepieceConstants.AVERAGE_ERROR_PIXELS,
+        VisionGamepieceConstants.AVERAGE_STANDARD_DEVIATION_PIXELS);
+    cameraProp.setFPS(VisionGamepieceConstants.FPS);
+    cameraProp.setAvgLatencyMs(VisionGamepieceConstants.AVERAGE_LATENCY_MS);
+    cameraProp.setLatencyStdDevMs(VisionGamepieceConstants.AVERAGE_STANDARD_DEVIATION_MS);
 
     var networkName = "gamepieceCameraSim";
     this.camera = new PhotonCamera(networkName);
@@ -62,25 +65,11 @@ public class VisionGamepieceIOSim implements VisionGamepieceIO {
     var results = camera.getLatestResult();
 
     var aprilTagYaw = 0.0;
-    for (int i = 0; i < results.getTargets().size(); i++) {
+    for (int i = 0;
+        i < results.getTargets().size();
+        i++) { // TODO: Add logic for which tags to detect
       PhotonTrackedTarget target = results.targets.get(i);
-      int targetID = target.getFiducialId();
-      if (DriverStation.getAlliance().isPresent()) {
-        boolean isRed = DriverStation.getAlliance().get().equals(Alliance.Red);
-        boolean isBlue = DriverStation.getAlliance().get().equals(Alliance.Blue);
-        boolean condition1 = (isRed && (targetID >= 11 && targetID <= 13));
-        boolean condition2 = (isBlue && (targetID >= 14 && targetID <= 16));
-
-        Logger.recordOutput("VisionGamepiece/isBlue", isBlue);
-        Logger.recordOutput("VisionGamepiece/isRed", isRed);
-
-        Logger.recordOutput("VisionGamepiece/condition1", condition1);
-        Logger.recordOutput("VisionGamepiece/condition2", condition2);
-
-        if (condition1 || condition2) {
-          aprilTagYaw = target.getYaw();
-        }
-      }
+      aprilTagYaw = target.getYaw();
     }
 
     inputs.aprilTagYaw = aprilTagYaw;


### PR DESCRIPTION
- TalonFXSim + TalonFXElevatorSim + TalonFXArmSim
- take max voltage out of shooter
- Elevator: move INCHES_TO_MOTOR_ROT to constants
- Make elevator current constant not a distance measure
- Make pulley diameter a measure
- remove the 0.0 from various Input classes (java allocates this on its own)
- Move other max current numbers to constants
- mm constraint methods Elevator class
- mm configs object rather than constraints io
- change name of elevator config method to others
- make motor objects final
- remove current and default constraints methods elevator + remove variable (unused)
- target positions/velocities logging
- set voltages to 0 in all subsystem constructors
- log control mode
- comments